### PR TITLE
[WOC] Update all leaderboard UI for responsiveness and design consistency (#69)

### DIFF
--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -636,7 +636,7 @@ export default function GroupEventLeaderboardPage() {
                       </span>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex flex-col gap-2 max-w-xs">
+                      <div className="flex flex-col gap-2 min-w-[300px]">
                         {eventMetadata.judgeIdList.map((judgeId, i) => {
                           const comment = group.comment[eventName][judgeId];
                           if (!comment || comment === '-') return null;
@@ -648,7 +648,7 @@ export default function GroupEventLeaderboardPage() {
                               <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
                                 Judge {i + 1}
                               </p>
-                              <p className="text-xs text-gray-700 leading-relaxed">
+                              <p className="text-xs text-gray-700 leading-relaxed whitespace-normal">
                                 {comment}
                               </p>
                             </div>

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -507,10 +507,10 @@ export default function GroupEventLeaderboardPage() {
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="sticky left-0 z-20 px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 w-20">
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
                     Rank
                   </th>
-                  <th className="sticky left-20 z-20 px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 border-r border-gray-200 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
                     Group Information
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
@@ -523,7 +523,16 @@ export default function GroupEventLeaderboardPage() {
                           key={index}
                           className="px-2 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
-                          {criteria}
+                          {criteria.split('&').map((part, i, arr) => (
+                            <span key={i}>
+                              {part}
+                              {i < arr.length - 1 && (
+                                <>
+                                  &<br />
+                                </>
+                              )}
+                            </span>
+                          ))}
                         </th>
                       ),
                     )}
@@ -544,12 +553,12 @@ export default function GroupEventLeaderboardPage() {
                     key={index}
                     className="hover:bg-gray-50 transition-colors"
                   >
-                    <td className="sticky left-0 z-20 px-4 py-4 whitespace-nowrap bg-white w-20">
+                    <td className="px-6 py-4 whitespace-nowrap">
                       <span className="text-sm font-bold text-gray-900">
                         #{index + 1}
                       </span>
                     </td>
-                    <td className="sticky left-20 z-20 px-6 py-4 whitespace-nowrap bg-white border-r border-gray-100 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
+                    <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm font-bold text-gray-900">
                         {group.district}
                       </div>

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -617,17 +617,22 @@ export default function GroupEventLeaderboardPage() {
                         ),
                       )}
                     <td className="px-6 py-4 text-center">
-                      <div className="flex flex-col gap-1">
-                        {Object.values(group.judgeWiseTotal).map(
-                          (total, idx) => (
-                            <span
-                              key={idx}
-                              className="text-xs font-bold text-gray-900 tabular-nums"
-                            >
-                              {parseFloat(total).toFixed(2)}
+                      <div className="flex flex-col gap-1 items-center">
+                        {eventMetadata.judgeIdList.map((judgeId, idx) => (
+                          <div
+                            key={idx}
+                            className="flex items-center gap-2 justify-between w-16"
+                          >
+                            <span className="text-[10px] text-gray-400 font-medium">
+                              J{idx + 1}
                             </span>
-                          ),
-                        )}
+                            <span className="text-xs font-bold text-gray-900 tabular-nums text-right">
+                              {parseFloat(
+                                group.judgeWiseTotal[judgeId] || 0,
+                              ).toFixed(2)}
+                            </span>
+                          </div>
+                        ))}
                       </div>
                     </td>
                     <td className="px-6 py-4 text-center whitespace-nowrap">

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -632,7 +632,7 @@ export default function GroupEventLeaderboardPage() {
                       </span>
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex flex-col gap-2 min-w-[300px]">
+                      <div className="flex flex-col gap-2">
                         {eventMetadata.judgeIdList.map((judgeId, i) => {
                           const comment = group.comment[eventName][judgeId];
                           if (!comment || comment === '-') return null;

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -503,7 +503,7 @@ export default function GroupEventLeaderboardPage() {
             </div>
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="hidden md:block overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
@@ -521,9 +521,18 @@ export default function GroupEventLeaderboardPage() {
                       (criteria, index) => (
                         <th
                           key={index}
-                          className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
+                          className="px-2 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
-                          {criteria}
+                          {criteria.split('&').map((part, i, arr) => (
+                            <span key={i}>
+                              {part}
+                              {i < arr.length - 1 && (
+                                <>
+                                  &<br />
+                                </>
+                              )}
+                            </span>
+                          ))}
                         </th>
                       ),
                     )}
@@ -592,7 +601,7 @@ export default function GroupEventLeaderboardPage() {
                         (criteria, i1) => (
                           <td
                             key={i1}
-                            className="px-6 py-4 text-center"
+                            className="px-2 py-4 text-center"
                           >
                             <div className="flex flex-col gap-1">
                               {eventMetadata.judgeIdList.map((judgeId, i2) => (
@@ -660,6 +669,116 @@ export default function GroupEventLeaderboardPage() {
                 ))}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile Card View */}
+          <div className="md:hidden flex flex-col gap-4 p-4 bg-gray-50">
+            {groups.map((group, index) => (
+              <div
+                key={index}
+                className="bg-white rounded-xl p-4 shadow-sm border border-gray-200"
+              >
+                <div className="flex justify-between items-start mb-3">
+                  <div className="flex items-center gap-2">
+                    <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
+                      #{index + 1}
+                    </span>
+                    <div>
+                      <h3 className="text-sm font-bold text-gray-900">
+                        {group.district ?? 'Unknown'}
+                      </h3>
+                      <p className="text-xs text-gray-500">
+                        {group.members.length} members
+                      </p>
+                    </div>
+                  </div>
+                  <span className="text-lg font-black text-blue-600">
+                    {parseFloat(group.overallTotal).toFixed(2)}
+                  </span>
+                </div>
+
+                <div className="mb-4">
+                  <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
+                    Members
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {group.members.map((member, i) => (
+                      <div
+                        key={i}
+                        className="flex flex-col bg-gray-50 rounded p-2 text-xs border border-gray-100 flex-1 min-w-[120px]"
+                      >
+                        <span className="font-medium text-gray-900 truncate">
+                          {member.name}
+                        </span>
+                        <div className="flex justify-between mt-1 items-center">
+                          <span className="text-gray-500 text-[10px]">
+                            {member.id}
+                          </span>
+                          <span
+                            className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold border ${
+                              member.ATTENDEE_STATUS === 'Attended'
+                                ? 'bg-green-50 text-green-700 border-green-100'
+                                : 'bg-yellow-50 text-yellow-700 border-yellow-100'
+                            }`}
+                          >
+                            {member.ATTENDEE_STATUS === 'Attended' ? 'P' : 'A'}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="bg-gray-50 rounded-lg p-3 space-y-2">
+                  <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
+                    <span>Judge Scores</span>
+                    <span>Total</span>
+                  </div>
+                  {eventMetadata.judgeIdList.map((judgeId, i) => (
+                    <div
+                      key={i}
+                      className="flex justify-between items-center text-xs"
+                    >
+                      <span className="text-gray-600">Judge {i + 1}</span>
+                      <span className="font-bold text-gray-900">
+                        {parseFloat(group.judgeWiseTotal[judgeId] || 0).toFixed(
+                          2,
+                        )}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+
+                {eventMetadata.judgeIdList.some(
+                  (jid) =>
+                    group.comment[eventName][jid] &&
+                    group.comment[eventName][jid] !== '-',
+                ) && (
+                  <div className="mt-3 pt-3 border-t border-gray-100">
+                    <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
+                      Comments
+                    </p>
+                    <div className="space-y-2">
+                      {eventMetadata.judgeIdList.map((judgeId, i) => {
+                        const comment = group.comment[eventName][judgeId];
+                        if (!comment || comment === '-') return null;
+                        return (
+                          <div
+                            key={i}
+                            className="text-xs text-gray-600"
+                          >
+                            <span className="font-semibold text-gray-800">
+                              J{i + 1}:{' '}
+                            </span>{' '}
+                            {comment}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -372,28 +372,30 @@ export default function GroupEventLeaderboardPage() {
   };
 
   return eventName && user && eventMetadata && groups ? (
-    <>
-      <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-        <div className="rounded-2xl p-4 m-2 bg-white border overflow-x-auto justify-between flex flex-row">
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <h1 className="text-2xl font-bold">Welcome, {user.name}</h1>
-            <p className="text-gray-700 mt-2">{user.email}</p>
+            <h1 className="text-2xl font-bold text-gray-900">
+              Welcome, {user.name}
+            </h1>
+            <p className="text-gray-500">{user.email}</p>
           </div>
-          <div className="flex flex-row">
+          <div className="flex gap-3 w-full md:w-auto">
             <button
-              className="bg-[#fffece] text-[#2c350b] font-bold px-4 py-1 rounded-xl mr-2"
+              className="flex-1 md:flex-none bg-yellow-100 text-yellow-800 hover:bg-yellow-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => router.push('/admin/event')}
             >
               Events
             </button>
             <button
-              className="bg-[#fffece] text-[#2c350b] font-bold px-4 py-1 rounded-xl mr-2"
+              className="flex-1 md:flex-none bg-blue-100 text-blue-800 hover:bg-blue-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => router.push('/admin')}
             >
               Dashboard
             </button>
             <button
-              className="bg-[#ffcece] text-[#350b0b] font-bold px-4 py-1 rounded-xl"
+              className="flex-1 md:flex-none bg-red-100 text-red-800 hover:bg-red-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => {
                 auth.signOut();
                 secureLocalStorage.clear();
@@ -405,168 +407,254 @@ export default function GroupEventLeaderboardPage() {
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 bg-white border overflow-x-auto">
-            <h1 className="text-2xl font-bold">{eventMetadata.name}</h1>
-            <p className="text-md">{groups.length} Groups</p>
-            <div className="flex flex-row flex-wrap gap-1 mt-1">
-              {eventMetadata.group.map((group, index) => (
-                <p
-                  key={index}
-                  className="bg-gray-200 text-gray-800 font-semibold px-2 py-1 rounded-xl w-fit"
-                >
-                  {group}
-                </p>
-              ))}
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6">
+          <div className="flex flex-col md:flex-row justify-between gap-6">
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                {eventMetadata.name}
+              </h2>
+              <p className="text-gray-500 mb-4">
+                {groups.length} Groups registered
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {eventMetadata.group.map((group, index) => (
+                  <span
+                    key={index}
+                    className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 border border-gray-200"
+                  >
+                    {group}
+                  </span>
+                ))}
+              </div>
             </div>
-
-            {/* Evaluation Criteria */}
-            <h2 className="text-xl font-bold mt-6">Evaluation Criteria</h2>
-            <table className="table-auto w-full">
-              <thead>
-                <tr>
-                  <th className="border px-4 py-2">Criteria</th>
-                  <th className="border px-4 py-2">Max Marks</th>
-                </tr>
-              </thead>
-              <tbody>
+            <div className="w-full md:w-80">
+              <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                Evaluation Criteria
+              </h3>
+              <div className="space-y-2">
                 {Object.entries(eventMetadata.evalCriteria).map(
                   ([key, value], index) => (
-                    <tr key={index}>
-                      <td className="border px-4 py-2">{key}</td>
-                      <td className="border px-4 py-2">{value}</td>
-                    </tr>
+                    <div
+                      key={index}
+                      className="flex justify-between items-center text-sm"
+                    >
+                      <span className="text-gray-600">{key}</span>
+                      <span className="font-semibold text-gray-900 bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
+                        {value} pts
+                      </span>
+                    </div>
                   ),
                 )}
-                <tr>
-                  <td className="border px-4 py-2 font-semibold">Total</td>
-                  <td className="border px-4 py-2 font-semibold">
+                <div className="pt-2 mt-2 border-t border-gray-100 flex justify-between items-center font-bold text-gray-900">
+                  <span>Total Maximum Marks</span>
+                  <span className="text-blue-600">
                     {Object.values(eventMetadata.evalCriteria).reduce(
                       (a, b) => a + b,
                       0,
-                    )}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                    )}{' '}
+                    pts
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 my-4 bg-white border overflow-x-auto">
-            <div className="w-full flex justify-between">
-              <h1 className="text-2xl font-bold">Leaderboard</h1>
-              <div className="flex gap-2">
-                <button
-                  onClick={exportForCert}
-                  className="px-4 py-1 text-md bg-green-500 text-white rounded-lg hover:bg-green-600"
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+          <div className="p-6 border-b border-gray-100 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
+            <div className="flex gap-2 w-full sm:w-auto">
+              <button
+                onClick={exportForCert}
+                className="flex-1 sm:flex-none items-center justify-center inline-flex gap-2 bg-green-100 text-green-700 hover:bg-green-200 font-semibold px-4 py-2 rounded-xl transition-colors"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
                 >
-                  Export for Cert
-                </button>
-                <button
-                  onClick={exportToCSV}
-                  className="px-4 py-1 text-md bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                  <path
+                    fillRule="evenodd"
+                    d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                Cert Export
+              </button>
+              <button
+                onClick={exportToCSV}
+                className="flex-1 sm:flex-none items-center justify-center inline-flex gap-2 bg-blue-100 text-blue-700 hover:bg-blue-200 font-semibold px-4 py-2 rounded-xl transition-colors"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
                 >
-                  Export
-                </button>
-              </div>
+                  <path
+                    fillRule="evenodd"
+                    d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                Full CSV
+              </button>
             </div>
-            <table className="table-auto w-full mt-4">
-              <thead>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
                 <tr>
-                  <th className="border px-4 py-2">District</th>
-                  <th className="border px-4 py-2">Students</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Rank
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    District Information
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Group Members
+                  </th>
                   {eventMetadata.evalCriteria &&
                     Object.keys(eventMetadata.evalCriteria).map(
                       (criteria, index) => (
                         <th
                           key={index}
-                          className="border px-4 py-2"
+                          className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
                           {criteria}
                         </th>
                       ),
                     )}
-                  <th className="border px-4 py-2">Judge Wise Total</th>
-                  <th className="border px-4 py-2">Overall Total</th>
-                  <th className="border px-4 py-2">Comments</th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Judge Wise
+                  </th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Total
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Comments
+                  </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="bg-white divide-y divide-gray-200">
                 {groups.map((group, index) => (
-                  <tr key={index}>
-                    <td className="px-4 py-2 border font-bold">
-                      {group.district ?? 'Unknown'}
+                  <tr
+                    key={index}
+                    className="hover:bg-gray-50 transition-colors"
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span className="text-sm font-bold text-gray-900">
+                        #{index + 1}
+                      </span>
                     </td>
-                    <td className="px-4 py-2 border">
-                      {group.members.map((member, i) => (
-                        <div
-                          key={i}
-                          className="mt-2"
-                        >
-                          {/* First line: ID + Name */}
-                          <div className="flex items-center gap-2 text-xs">
-                            <span className="font-bold bg-gray-100 px-2 py-0.5 rounded-2xl">
-                              {member.id}
-                            </span>
-                            <span>{member.name}</span>
-                          </div>
-
-                          {/* Second line: Attendance */}
-                          <span
-                            className={`inline-block mt-1 text-[10px] font-semibold px-2 py-0.5 rounded-full ${
-                              member.ATTENDEE_STATUS === 'Attended'
-                                ? 'bg-green-100 text-green-700 border border-green-300'
-                                : 'bg-yellow-100 text-yellow-700 border border-yellow-300'
-                            }`}
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="text-sm font-bold text-gray-900">
+                        {group.district ?? 'Unknown'}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {group.members.length} members
+                      </div>
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex flex-col gap-2">
+                        {group.members.map((member, i) => (
+                          <div
+                            key={i}
+                            className="flex flex-col sm:flex-row sm:items-center gap-2"
                           >
-                            {member.ATTENDEE_STATUS === 'Attended'
-                              ? 'Present'
-                              : 'Yet to Check In'}
-                          </span>
-                        </div>
-                      ))}
+                            <span className="text-sm font-medium text-gray-900 whitespace-nowrap">
+                              {member.name}
+                            </span>
+                            <div className="flex items-center gap-1">
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                                {member.id}
+                              </span>
+                              <span
+                                className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border ${
+                                  member.ATTENDEE_STATUS === 'Attended'
+                                    ? 'bg-green-50 text-green-700 border-green-100'
+                                    : 'bg-yellow-50 text-yellow-700 border-yellow-100'
+                                }`}
+                              >
+                                {member.ATTENDEE_STATUS === 'Attended'
+                                  ? 'P'
+                                  : 'A'}
+                              </span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
                     </td>
                     {eventMetadata.evalCriteria &&
                       Object.keys(eventMetadata.evalCriteria).map(
                         (criteria, i1) => (
                           <td
                             key={i1}
-                            className="px-4 py-2 border"
+                            className="px-6 py-4 text-center"
                           >
-                            {eventMetadata.judgeIdList.map((judgeId, i2) => (
-                              <p
-                                key={i2}
-                                className="text-xs"
-                              >
-                                {group.score[eventName][judgeId][criteria]}
-                              </p>
-                            ))}
+                            <div className="flex flex-col gap-1">
+                              {eventMetadata.judgeIdList.map((judgeId, i2) => (
+                                <span
+                                  key={i2}
+                                  className="text-xs font-medium text-gray-600 tabular-nums"
+                                >
+                                  {group.score[eventName][judgeId][criteria]}
+                                </span>
+                              ))}
+                            </div>
                           </td>
                         ),
                       )}
-                    <td className="px-4 py-2 border font-bold">
-                      {Object.values(group.judgeWiseTotal).map((total, i) => (
-                        <p
-                          key={i}
-                          className="text-xs"
-                        >
-                          {parseFloat(total).toFixed(2)}
-                        </p>
-                      ))}
+                    <td className="px-6 py-4 text-center">
+                      <div className="flex flex-col gap-1">
+                        {Object.values(group.judgeWiseTotal).map(
+                          (total, idx) => (
+                            <span
+                              key={idx}
+                              className="text-xs font-bold text-gray-900 tabular-nums"
+                            >
+                              {parseFloat(total).toFixed(2)}
+                            </span>
+                          ),
+                        )}
+                      </div>
                     </td>
-                    <td className="px-4 py-2 border font-bold">
-                      {parseFloat(group.overallTotal).toFixed(2)}
+                    <td className="px-6 py-4 text-center whitespace-nowrap">
+                      <span className="text-sm font-black text-blue-600 tabular-nums">
+                        {parseFloat(group.overallTotal).toFixed(2)}
+                      </span>
                     </td>
-                    <td className="px-4 py-2 border">
-                      {eventMetadata.judgeIdList.map((judgeId, i2) => (
-                        <p
-                          key={i2}
-                          className="text-xs"
-                        >
-                          {group.comment[eventName][judgeId]}
-                        </p>
-                      ))}
+                    <td className="px-6 py-4">
+                      <div className="flex flex-col gap-2 max-w-xs">
+                        {eventMetadata.judgeIdList.map((judgeId, i) => {
+                          const comment = group.comment[eventName][judgeId];
+                          if (!comment || comment === '-') return null;
+                          return (
+                            <div
+                              key={i}
+                              className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                            >
+                              <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
+                                Judge {i + 1}
+                              </p>
+                              <p className="text-xs text-gray-700 leading-relaxed">
+                                {comment}
+                              </p>
+                            </div>
+                          );
+                        })}
+                        {!eventMetadata.judgeIdList.some(
+                          (jid) =>
+                            group.comment[eventName][jid] &&
+                            group.comment[eventName][jid] !== '-',
+                        ) && (
+                          <span className="text-gray-400 italic text-xs">
+                            No comments
+                          </span>
+                        )}
+                      </div>
                     </td>
                   </tr>
                 ))}
@@ -575,10 +663,13 @@ export default function GroupEventLeaderboardPage() {
           </div>
         </div>
       </div>
-    </>
+    </div>
   ) : (
-    <div className="flex h-screen items-center justify-center">
-      <p className="text-xl font-semibold">Loading...</p>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="flex flex-col items-center gap-4">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+        <p className="text-gray-500 font-medium">Loading leaderboard...</p>
+      </div>
     </div>
   );
 }

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -507,14 +507,14 @@ export default function GroupEventLeaderboardPage() {
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  <th className="sticky left-0 z-20 px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 w-20">
                     Rank
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                    District Information
+                  <th className="sticky left-20 z-20 px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 border-r border-gray-200 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
+                    Group Information
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                    Group Members
+                    Member Details
                   </th>
                   {eventMetadata.evalCriteria &&
                     Object.keys(eventMetadata.evalCriteria).map(
@@ -544,14 +544,14 @@ export default function GroupEventLeaderboardPage() {
                     key={index}
                     className="hover:bg-gray-50 transition-colors"
                   >
-                    <td className="px-6 py-4 whitespace-nowrap">
+                    <td className="sticky left-0 z-20 px-4 py-4 whitespace-nowrap bg-white w-20">
                       <span className="text-sm font-bold text-gray-900">
                         #{index + 1}
                       </span>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
+                    <td className="sticky left-20 z-20 px-6 py-4 whitespace-nowrap bg-white border-r border-gray-100 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
                       <div className="text-sm font-bold text-gray-900">
-                        {group.district ?? 'Unknown'}
+                        {group.district}
                       </div>
                       <div className="text-xs text-gray-500">
                         {group.members.length} members

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -523,16 +523,7 @@ export default function GroupEventLeaderboardPage() {
                           key={index}
                           className="px-2 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
-                          {criteria.split('&').map((part, i, arr) => (
-                            <span key={i}>
-                              {part}
-                              {i < arr.length - 1 && (
-                                <>
-                                  &<br />
-                                </>
-                              )}
-                            </span>
-                          ))}
+                          {criteria}
                         </th>
                       ),
                     )}

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -737,7 +737,7 @@ export default function EventLeaderboardIndiPage() {
                           : row.studentId}
                       </span>
                     </div>
-                    <div className="flex flex-col">
+                    <div className="flex flex-col items-end text-right">
                       <span className="text-gray-400">Status</span>
                       <span
                         className={`inline-flex w-fit items-center px-2 py-0.5 rounded text-[10px] font-bold border ${

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -503,10 +503,10 @@ export default function EventLeaderboardIndiPage() {
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="sticky left-0 z-20 px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 w-20">
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
                     Rank
                   </th>
-                  <th className="sticky left-20 z-20 px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 border-r border-gray-200 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
                     Student Information
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
@@ -519,7 +519,16 @@ export default function EventLeaderboardIndiPage() {
                           key={index}
                           className="px-2 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
-                          {criteria}
+                          {criteria.split('&').map((part, i, arr) => (
+                            <span key={i}>
+                              {part}
+                              {i < arr.length - 1 && (
+                                <>
+                                  &<br />
+                                </>
+                              )}
+                            </span>
+                          ))}
                         </th>
                       ),
                     )}
@@ -543,12 +552,12 @@ export default function EventLeaderboardIndiPage() {
                       key={index}
                       className={`hover:bg-gray-50 transition-colors ${isSubstituted ? 'bg-red-50/50' : ''}`}
                     >
-                      <td className="sticky left-0 z-20 px-4 py-4 whitespace-nowrap bg-white w-20">
+                      <td className="px-6 py-4 whitespace-nowrap">
                         <span className="text-sm font-bold text-gray-900">
                           #{index + 1}
                         </span>
                       </td>
-                      <td className="sticky left-20 z-20 px-6 py-4 bg-white border-r border-gray-100 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
+                      <td className="px-6 py-4">
                         {isSubstituted ? (
                           <div className="flex flex-col">
                             <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -737,7 +737,7 @@ export default function EventLeaderboardIndiPage() {
                           : row.studentId}
                       </span>
                     </div>
-                    <div className="flex flex-col items-end text-right">
+                    <div className="flex flex-row items-center justify-end gap-2">
                       <span className="text-gray-400">Status</span>
                       <span
                         className={`inline-flex w-fit items-center px-2 py-0.5 rounded text-[10px] font-bold border ${

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -647,7 +647,7 @@ export default function EventLeaderboardIndiPage() {
                         </span>
                       </td>
                       <td className="px-6 py-4">
-                        <div className="flex flex-col gap-2 max-w-xs">
+                        <div className="flex flex-col gap-2 min-w-[300px]">
                           {eventMetadata.judgeIdList.map((judgeId, i) => {
                             const comment = row.comment[eventName][judgeId];
                             if (!comment) return null;
@@ -659,7 +659,7 @@ export default function EventLeaderboardIndiPage() {
                                 <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
                                   Judge {i + 1}
                                 </p>
-                                <p className="text-xs text-gray-700 leading-relaxed">
+                                <p className="text-xs text-gray-700 leading-relaxed whitespace-normal">
                                   {comment}
                                 </p>
                               </div>

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -503,10 +503,10 @@ export default function EventLeaderboardIndiPage() {
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  <th className="sticky left-0 z-20 px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 w-20">
                     Rank
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  <th className="sticky left-20 z-20 px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider bg-gray-50 border-r border-gray-200 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
                     Student Information
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
@@ -543,12 +543,12 @@ export default function EventLeaderboardIndiPage() {
                       key={index}
                       className={`hover:bg-gray-50 transition-colors ${isSubstituted ? 'bg-red-50/50' : ''}`}
                     >
-                      <td className="px-6 py-4 whitespace-nowrap">
+                      <td className="sticky left-0 z-20 px-4 py-4 whitespace-nowrap bg-white w-20">
                         <span className="text-sm font-bold text-gray-900">
                           #{index + 1}
                         </span>
                       </td>
-                      <td className="px-6 py-4">
+                      <td className="sticky left-20 z-20 px-6 py-4 bg-white border-r border-gray-100 shadow-[2px_0_5px_-2px_rgba(0,0,0,0.1)]">
                         {isSubstituted ? (
                           <div className="flex flex-col">
                             <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -519,16 +519,7 @@ export default function EventLeaderboardIndiPage() {
                           key={index}
                           className="px-2 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
-                          {criteria.split('&').map((part, i, arr) => (
-                            <span key={i}>
-                              {part}
-                              {i < arr.length - 1 && (
-                                <>
-                                  &<br />
-                                </>
-                              )}
-                            </span>
-                          ))}
+                          {criteria}
                         </th>
                       ),
                     )}

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -367,28 +367,30 @@ export default function EventLeaderboardIndiPage() {
     eventMetadata &&
     participants &&
     filteredParticipants ? (
-    <>
-      <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-        <div className="rounded-2xl p-4 m-2 bg-white border overflow-x-auto justify-between flex flex-row">
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <h1 className="text-2xl font-bold">Welcome, {user.name}</h1>
-            <p className="text-gray-700 mt-2">{user.email}</p>
+            <h1 className="text-2xl font-bold text-gray-900">
+              Welcome, {user.name}
+            </h1>
+            <p className="text-gray-500">{user.email}</p>
           </div>
-          <div className="flex flex-row">
+          <div className="flex gap-3 w-full md:w-auto">
             <button
-              className="bg-[#fffece] text-[#2c350b] font-bold px-4 py-1 rounded-xl mr-2"
+              className="flex-1 md:flex-none bg-yellow-100 text-yellow-800 hover:bg-yellow-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => router.push('/admin/event')}
             >
               Events
             </button>
             <button
-              className="bg-[#fffece] text-[#2c350b] font-bold px-4 py-1 rounded-xl mr-2"
+              className="flex-1 md:flex-none bg-blue-100 text-blue-800 hover:bg-blue-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => router.push('/admin')}
             >
               Dashboard
             </button>
             <button
-              className="bg-[#ffcece] text-[#350b0b] font-bold px-4 py-1 rounded-xl"
+              className="flex-1 md:flex-none bg-red-100 text-red-800 hover:bg-red-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => {
                 auth.signOut();
                 secureLocalStorage.clear();
@@ -400,242 +402,284 @@ export default function EventLeaderboardIndiPage() {
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 bg-white border overflow-x-auto">
-            <h1 className="text-2xl font-bold">{eventMetadata.name}</h1>
-            <p className="text-md">{participants.length} Participants</p>
-            <div className="flex flex-row flex-wrap gap-1 mt-1">
-              {eventMetadata.group.map((group, index) => (
-                <p
-                  key={index}
-                  className="bg-gray-200 text-gray-800 font-semibold px-2 py-1 rounded-xl w-fit"
-                >
-                  {group}
-                </p>
-              ))}
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6">
+          <div className="flex flex-col md:flex-row justify-between gap-6">
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                {eventMetadata.name}
+              </h2>
+              <p className="text-gray-500 mb-4">
+                {participants.length} Participants enrolled
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {eventMetadata.group.map((group, index) => (
+                  <span
+                    key={index}
+                    className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 border border-gray-200"
+                  >
+                    {group}
+                  </span>
+                ))}
+              </div>
             </div>
-
-            {/* Evaluation Criteria */}
-            <h2 className="text-xl font-bold mt-6">Evaluation Criteria</h2>
-            <table className="table-auto w-full">
-              <thead>
-                <tr>
-                  <th className="border px-4 py-2">Criteria</th>
-                  <th className="border px-4 py-2">Max Marks</th>
-                </tr>
-              </thead>
-              <tbody>
+            <div className="w-full md:w-80">
+              <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                Evaluation Criteria
+              </h3>
+              <div className="space-y-2">
                 {Object.entries(eventMetadata.evalCriteria).map(
                   ([key, value], index) => (
-                    <tr key={index}>
-                      <td className="border px-4 py-2">{key}</td>
-                      <td className="border px-4 py-2">{value}</td>
-                    </tr>
+                    <div
+                      key={index}
+                      className="flex justify-between items-center text-sm"
+                    >
+                      <span className="text-gray-600">{key}</span>
+                      <span className="font-semibold text-gray-900 bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
+                        {value} pts
+                      </span>
+                    </div>
                   ),
                 )}
-                <tr>
-                  <td className="border px-4 py-2 font-semibold">Total</td>
-                  <td className="border px-4 py-2 font-semibold">
+                <div className="pt-2 mt-2 border-t border-gray-100 flex justify-between items-center font-bold text-gray-900">
+                  <span>Total Maximum Marks</span>
+                  <span className="text-blue-600">
                     {Object.values(eventMetadata.evalCriteria).reduce(
                       (a, b) => a + b,
                       0,
-                    )}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                    )}{' '}
+                    pts
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 my-4 bg-white border overflow-x-auto">
-            <div className="w-full flex justify-between">
-              <h1 className="text-2xl font-bold">Leaderboard</h1>
-              <div className="flex gap-2">
-                <button
-                  onClick={exportForCert}
-                  className="px-4 py-1 text-md bg-green-500 text-white rounded-lg hover:bg-green-600"
+        {/* Leaderboard Card */}
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+          <div className="p-6 border-b border-gray-100 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
+            <div className="flex gap-2 w-full sm:w-auto">
+              <button
+                onClick={exportForCert}
+                className="flex-1 sm:flex-none items-center justify-center inline-flex gap-2 bg-green-100 text-green-700 hover:bg-green-200 font-semibold px-4 py-2 rounded-xl transition-colors"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
                 >
-                  Export for Cert
-                </button>
-                <button
-                  onClick={exportToCSV}
-                  className="px-4 py-1 text-md bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+                  <path
+                    fillRule="evenodd"
+                    d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                Cert Export
+              </button>
+              <button
+                onClick={exportToCSV}
+                className="flex-1 sm:flex-none items-center justify-center inline-flex gap-2 bg-blue-100 text-blue-700 hover:bg-blue-200 font-semibold px-4 py-2 rounded-xl transition-colors"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
                 >
-                  Export
-                </button>
-              </div>
+                  <path
+                    fillRule="evenodd"
+                    d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                Full CSV
+              </button>
             </div>
-            <table className="table-auto w-full mt-4">
-              <thead>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
                 <tr>
-                  <th className="border px-4 py-2">Student</th>
-                  <th className="border px-4 py-2">Balvikas</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Rank
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Student Information
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    District & Samithi
+                  </th>
                   {eventMetadata.evalCriteria &&
                     Object.keys(eventMetadata.evalCriteria).map(
                       (criteria, index) => (
                         <th
                           key={index}
-                          className="border px-4 py-2 text-center"
+                          className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
-                          {criteria.split(' ').map((word, i) => (
-                            <span
-                              key={i}
-                              className="block"
-                            >
-                              {word}
-                            </span>
-                          ))}
+                          {criteria}
                         </th>
                       ),
                     )}
-                  <th className="border px-4 py-2">Judge Wise Total</th>
-                  <th className="border px-4 py-2">Avg Total</th>
-                  <th className="border px-4 py-2">Comments</th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Judge Wise
+                  </th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Avg Total
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Comments
+                  </th>
                 </tr>
               </thead>
-              <tbody>
-                {filteredParticipants.map((row, index) => (
-                  <tr key={index}>
-                    <td
-                      className={
-                        'px-4 py-2 border max-w-40' +
-                        (row.substitute && row.substitute[eventMetadata.name]
-                          ? ' bg-[#ffcece]'
-                          : '')
-                      }
+              <tbody className="bg-white divide-y divide-gray-200">
+                {filteredParticipants.map((row, index) => {
+                  const isSubstituted =
+                    row.substitute && row.substitute[eventMetadata.name];
+                  return (
+                    <tr
+                      key={index}
+                      className={`hover:bg-gray-50 transition-colors ${isSubstituted ? 'bg-red-50/50' : ''}`}
                     >
-                      {row.substitute && row.substitute[eventMetadata.name] ? (
-                        <div>
-                          <p className="text-xs font-semibold text-[#32350b] rounded-2xl w-fit">
-                            Substituted Student - Original{' '}
-                            <span className="font-bold">{row.studentId}</span>
-                          </p>
-                          <p className="font-bold">
-                            {row.substitute[eventMetadata.name].newStudentName}
-                          </p>
-                          <p className="text-xs">
-                            {row.substitute[eventMetadata.name]
-                              .newStudentGender ?? '-'}{' '}
-                            -{' '}
-                            {row.substitute[eventMetadata.name].newStudentDOB ??
-                              '-'}
-                          </p>
-                          <p className="text-xs mt-2 font-bold bg-[#bad1ff] text-[#090e2d] p-1 px-2 rounded-2xl w-fit">
-                            {row.substitute[eventMetadata.name]
-                              .newStudentGroup ?? '-'}
-                          </p>
-                        </div>
-                      ) : (
-                        <div>
-                          <p className="font-bold">
-                            {row.studentFullName ?? '-'}
-                          </p>
-
-                          <span
-                            className={`inline-block mt-1 text-[10px] font-semibold px-2 py-0.5 rounded-full ${
-                              row.ATTENDEE_STATUS === 'Attended'
-                                ? 'bg-green-100 text-green-700 border border-green-300'
-                                : 'bg-yellow-100 text-yellow-700 border border-yellow-300'
-                            }`}
-                          >
-                            {row.ATTENDEE_STATUS === 'Attended'
-                              ? 'Present'
-                              : 'Yet to Check In'}
-                          </span>
-
-                          <p className="text-xs mt-1">
-                            {row.gender ?? '-'} - {row.dateOfBirth ?? '-'}
-                          </p>
-
-                          <div className="flex flex-wrap gap-1 mt-1">
-                            <p className="text-xs font-bold bg-[#c4ffc2] text-[#07210d] p-1 px-2 rounded-2xl w-fit">
-                              {row.studentId ?? '-'}
-                            </p>
-                            <p className="text-xs font-bold bg-[#bad1ff] text-[#090e2d] p-1 px-2 rounded-2xl w-fit">
-                              {row.studentGroup ?? '-'}
-                            </p>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className="text-sm font-bold text-gray-900">
+                          #{index + 1}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        {isSubstituted ? (
+                          <div className="flex flex-col">
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">
+                              SUBSTITUTE
+                            </span>
+                            <span className="text-sm font-bold text-gray-900">
+                              {
+                                row.substitute[eventMetadata.name]
+                                  .newStudentName
+                              }
+                            </span>
+                            <span className="text-xs text-gray-500">
+                              Orig ID: {row.studentId}
+                            </span>
                           </div>
-                        </div>
-                      )}
-                    </td>
-                    <td className="px-4 py-2 border max-w-50">
-                      <p className="font-bold">{row.district ?? '-'}</p>
-                      <p className="text-xs">{row.samithiName ?? '-'}</p>
-                      {row.studentGroup === 'Group 3' && (
-                        <p className="text-xs">
-                          Passed group 2: {row.hasPassedGroup2Exam ?? '-'}
-                        </p>
-                      )}
-                      <div className="flex flex-wrap mt-2 gap-1">
-                        {row.registeredEvents.map((event, index) => (
-                          <p
-                            key={index}
-                            className="text-xs bg-green-200 text-green-800 font-bold rounded-xl p-1 px-2 w-fit"
-                          >
-                            {event ?? '-'}
-                          </p>
-                        ))}
-                      </div>
-                    </td>
-                    {eventMetadata.evalCriteria &&
-                      Object.keys(eventMetadata.evalCriteria).map(
-                        (criteria, i1) => (
-                          <td
-                            key={i1}
-                            className="px-4 py-2 border"
-                          >
-                            {eventMetadata.judgeIdList.map((judgeId, i2) => (
-                              <p
-                                key={i2}
-                                className="text-xs"
+                        ) : (
+                          <div className="flex flex-col">
+                            <span className="text-sm font-bold text-gray-900">
+                              {row.studentFullName ?? '-'}
+                            </span>
+                            <div className="flex flex-wrap gap-2 mt-1">
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                                {row.studentId}
+                              </span>
+                              <span
+                                className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border ${
+                                  row.ATTENDEE_STATUS === 'Attended'
+                                    ? 'bg-green-50 text-green-700 border-green-100'
+                                    : 'bg-yellow-50 text-yellow-700 border-yellow-100'
+                                }`}
                               >
-                                {row.score[eventName][judgeId][criteria]}
-                              </p>
-                            ))}
-                          </td>
-                        ),
-                      )}
-                    <td className="px-4 py-2 border font-bold">
-                      {Object.values(row.judgeWiseTotal).map((total, index) => (
-                        <p
-                          key={index}
-                          className="text-xs"
-                        >
-                          {parseFloat(total).toFixed(2)}
-                        </p>
-                      ))}
-                    </td>
-                    <td className="px-4 py-2 border font-bold">
-                      {parseFloat(row.overallTotal).toFixed(2)}
-                    </td>
-                    <td className="px-4 py-2 border">
-                      <div className="flex flex-col">
-                        {eventMetadata.judgeIdList.map((judgeId, i) => (
-                          <div
-                            key={i}
-                            className="flex flex-col"
-                          >
-                            <p className="text-xs">
-                              {row.comment[eventName][judgeId] == ''
-                                ? '-'
-                                : row.comment[eventName][judgeId]}
-                            </p>
+                                {row.ATTENDEE_STATUS === 'Attended'
+                                  ? 'Present'
+                                  : 'Absent'}
+                              </span>
+                            </div>
                           </div>
-                        ))}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
+                        )}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-medium text-gray-900">
+                          {row.district ?? '-'}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {row.samithiName ?? '-'}
+                        </div>
+                      </td>
+                      {eventMetadata.evalCriteria &&
+                        Object.keys(eventMetadata.evalCriteria).map(
+                          (criteria, i1) => (
+                            <td
+                              key={i1}
+                              className="px-6 py-4 text-center"
+                            >
+                              <div className="flex flex-col gap-1">
+                                {eventMetadata.judgeIdList.map(
+                                  (judgeId, i2) => (
+                                    <span
+                                      key={i2}
+                                      className="text-xs font-medium text-gray-600 tabular-nums"
+                                    >
+                                      {row.score[eventName][judgeId][criteria]}
+                                    </span>
+                                  ),
+                                )}
+                              </div>
+                            </td>
+                          ),
+                        )}
+                      <td className="px-6 py-4 text-center">
+                        <div className="flex flex-col gap-1">
+                          {Object.values(row.judgeWiseTotal).map(
+                            (total, idx) => (
+                              <span
+                                key={idx}
+                                className="text-xs font-bold text-gray-900 tabular-nums"
+                              >
+                                {parseFloat(total).toFixed(2)}
+                              </span>
+                            ),
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-center whitespace-nowrap">
+                        <span className="text-sm font-black text-blue-600 tabular-nums">
+                          {parseFloat(row.overallTotal).toFixed(2)}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col gap-2 max-w-xs">
+                          {eventMetadata.judgeIdList.map((judgeId, i) => {
+                            const comment = row.comment[eventName][judgeId];
+                            if (!comment) return null;
+                            return (
+                              <div
+                                key={i}
+                                className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                              >
+                                <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
+                                  Judge {i + 1}
+                                </p>
+                                <p className="text-xs text-gray-700 leading-relaxed">
+                                  {comment}
+                                </p>
+                              </div>
+                            );
+                          })}
+                          {!eventMetadata.judgeIdList.some(
+                            (jid) => row.comment[eventName][jid],
+                          ) && (
+                            <span className="text-gray-400 italic text-xs">
+                              No comments
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
         </div>
       </div>
-    </>
+    </div>
   ) : (
-    <div className="flex h-screen items-center justify-center">
-      <p className="text-xl font-semibold">Loading...</p>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="flex flex-col items-center gap-4">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+        <p className="text-gray-500 font-medium">Loading leaderboard...</p>
+      </div>
     </div>
   );
 }

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -499,7 +499,7 @@ export default function EventLeaderboardIndiPage() {
             </div>
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="hidden md:block overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
@@ -517,9 +517,18 @@ export default function EventLeaderboardIndiPage() {
                       (criteria, index) => (
                         <th
                           key={index}
-                          className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
+                          className="px-2 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
                         >
-                          {criteria}
+                          {criteria.split('&').map((part, i, arr) => (
+                            <span key={i}>
+                              {part}
+                              {i < arr.length - 1 && (
+                                <>
+                                  &<br />
+                                </>
+                              )}
+                            </span>
+                          ))}
                         </th>
                       ),
                     )}
@@ -601,7 +610,7 @@ export default function EventLeaderboardIndiPage() {
                           (criteria, i1) => (
                             <td
                               key={i1}
-                              className="px-6 py-4 text-center"
+                              className="px-2 py-4 text-center"
                             >
                               <div className="flex flex-col gap-1">
                                 {eventMetadata.judgeIdList.map(
@@ -670,6 +679,130 @@ export default function EventLeaderboardIndiPage() {
                 })}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile Card View */}
+          <div className="md:hidden flex flex-col gap-4 p-4 bg-gray-50">
+            {filteredParticipants.map((row, index) => {
+              const isSubstituted =
+                row.substitute && row.substitute[eventMetadata.name];
+              return (
+                <div
+                  key={index}
+                  className={`bg-white rounded-xl p-4 shadow-sm border ${
+                    isSubstituted
+                      ? 'border-red-200 bg-red-50/10'
+                      : 'border-gray-200'
+                  }`}
+                >
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
+                        #{index + 1}
+                      </span>
+                      {isSubstituted ? (
+                        <div className="flex flex-col">
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">
+                            SUBSTITUTE
+                          </span>
+                          <span className="text-sm font-bold text-gray-900">
+                            {row.substitute[eventMetadata.name].newStudentName}
+                          </span>
+                        </div>
+                      ) : (
+                        <div>
+                          <h3 className="text-sm font-bold text-gray-900">
+                            {row.studentFullName ?? '-'}
+                          </h3>
+                        </div>
+                      )}
+                    </div>
+                    <span className="text-lg font-black text-blue-600">
+                      {parseFloat(row.overallTotal).toFixed(2)}
+                    </span>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-gray-600 mb-4">
+                    <div className="flex flex-col">
+                      <span className="text-gray-400">ID</span>
+                      <span className="font-medium">
+                        {isSubstituted
+                          ? row.substitute[eventMetadata.name].newStudentId ||
+                            'New ID'
+                          : row.studentId}
+                      </span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-gray-400">Status</span>
+                      <span
+                        className={`inline-flex w-fit items-center px-2 py-0.5 rounded text-[10px] font-bold border ${
+                          row.ATTENDEE_STATUS === 'Attended'
+                            ? 'bg-green-50 text-green-700 border-green-100'
+                            : 'bg-yellow-50 text-yellow-700 border-yellow-100'
+                        }`}
+                      >
+                        {row.ATTENDEE_STATUS === 'Attended'
+                          ? 'Present'
+                          : 'Absent'}
+                      </span>
+                    </div>
+                    <div className="flex flex-col col-span-2 mt-2">
+                      <span className="text-gray-400">Location</span>
+                      <span className="font-medium">
+                        {row.district ?? '-'} / {row.samithiName ?? '-'}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="bg-gray-50 rounded-lg p-3 space-y-2">
+                    <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
+                      <span>Judge Scores</span>
+                      <span>Total</span>
+                    </div>
+                    {eventMetadata.judgeIdList.map((judgeId, i) => (
+                      <div
+                        key={i}
+                        className="flex justify-between items-center text-xs"
+                      >
+                        <span className="text-gray-600">Judge {i + 1}</span>
+                        <span className="font-bold text-gray-900">
+                          {parseFloat(row.judgeWiseTotal[judgeId] || 0).toFixed(
+                            2,
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+
+                  {eventMetadata.judgeIdList.some(
+                    (jid) => row.comment[eventName][jid],
+                  ) && (
+                    <div className="mt-3 pt-3 border-t border-gray-100">
+                      <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
+                        Comments
+                      </p>
+                      <div className="space-y-2">
+                        {eventMetadata.judgeIdList.map((judgeId, i) => {
+                          const comment = row.comment[eventName][judgeId];
+                          if (!comment) return null;
+                          return (
+                            <div
+                              key={i}
+                              className="text-xs text-gray-600"
+                            >
+                              <span className="font-semibold text-gray-800">
+                                J{i + 1}:{' '}
+                              </span>{' '}
+                              {comment}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -737,7 +737,7 @@ export default function EventLeaderboardIndiPage() {
                           : row.studentId}
                       </span>
                     </div>
-                    <div className="flex flex-row items-center justify-end gap-2">
+                    <div className="flex flex-col items-end text-right">
                       <span className="text-gray-400">Status</span>
                       <span
                         className={`inline-flex w-fit items-center px-2 py-0.5 rounded text-[10px] font-bold border ${

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -643,7 +643,7 @@ export default function EventLeaderboardIndiPage() {
                         </span>
                       </td>
                       <td className="px-6 py-4">
-                        <div className="flex flex-col gap-2 min-w-[300px]">
+                        <div className="flex flex-col gap-2">
                           {eventMetadata.judgeIdList.map((judgeId, i) => {
                             const comment = row.comment[eventName][judgeId];
                             if (!comment) return null;

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -628,17 +628,22 @@ export default function EventLeaderboardIndiPage() {
                           ),
                         )}
                       <td className="px-6 py-4 text-center">
-                        <div className="flex flex-col gap-1">
-                          {Object.values(row.judgeWiseTotal).map(
-                            (total, idx) => (
-                              <span
-                                key={idx}
-                                className="text-xs font-bold text-gray-900 tabular-nums"
-                              >
-                                {parseFloat(total).toFixed(2)}
+                        <div className="flex flex-col gap-1 items-center">
+                          {eventMetadata.judgeIdList.map((judgeId, idx) => (
+                            <div
+                              key={idx}
+                              className="flex items-center gap-2 justify-between w-16"
+                            >
+                              <span className="text-[10px] text-gray-400 font-medium">
+                                J{idx + 1}
                               </span>
-                            ),
-                          )}
+                              <span className="text-xs font-bold text-gray-900 tabular-nums text-right">
+                                {parseFloat(
+                                  row.judgeWiseTotal[judgeId] || 0,
+                                ).toFixed(2)}
+                              </span>
+                            </div>
+                          ))}
                         </div>
                       </td>
                       <td className="px-6 py-4 text-center whitespace-nowrap">

--- a/app/judge/group/leaderboard/page.js
+++ b/app/judge/group/leaderboard/page.js
@@ -114,22 +114,24 @@ export default function GroupEventLeaderboardPage() {
   }, [router, eventName, searchParams]);
 
   return eventName && user && eventMetadata && groups ? (
-    <>
-      <div className="flex flex-col justify-center w-screen min-w-[95%] ml-auto mr-auto">
-        <div className="rounded-2xl p-4 m-2 bg-white border overflow-x-auto justify-between flex flex-col md:flex-row">
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <h1 className="text-2xl font-bold">Welcome, {user.name}</h1>
-            <p className="text-gray-700 mt-2">{user.email}</p>
+            <h1 className="text-2xl font-bold text-gray-900">
+              Welcome, {user.name}
+            </h1>
+            <p className="text-gray-500">{user.email}</p>
           </div>
-          <div className="flex flex-row">
+          <div className="flex gap-3 w-full md:w-auto">
             <button
-              className="bg-[#fffece] text-[#2c350b] font-bold px-4 py-1 rounded-xl mr-2"
+              className="flex-1 md:flex-none bg-yellow-100 text-yellow-800 hover:bg-yellow-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => router.push('/judge/group')}
             >
               Dashboard
             </button>
             <button
-              className="bg-[#ffcece] text-[#350b0b] font-bold px-4 py-1 rounded-xl"
+              className="flex-1 md:flex-none bg-red-100 text-red-800 hover:bg-red-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => {
                 auth.signOut();
                 secureLocalStorage.clear();
@@ -141,129 +143,174 @@ export default function GroupEventLeaderboardPage() {
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 bg-white border overflow-x-auto">
-            <h1 className="text-xl font-bold">{eventMetadata.name}</h1>
-            <p className="text-md">{groups.length} Groups</p>
-            <div className="flex flex-row flex-wrap gap-1 mt-1">
-              {eventMetadata.group.map((group, index) => (
-                <p
-                  key={index}
-                  className="bg-gray-200 text-gray-800 font-semibold px-2 py-1 rounded-xl w-fit"
-                >
-                  {group}
-                </p>
-              ))}
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6">
+          <div className="flex flex-col md:flex-row justify-between gap-6">
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                {eventMetadata.name}
+              </h2>
+              <p className="text-gray-500 mb-4">
+                {groups.length} Groups registered
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {eventMetadata.group.map((group, index) => (
+                  <span
+                    key={index}
+                    className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 border border-gray-200"
+                  >
+                    {group}
+                  </span>
+                ))}
+              </div>
             </div>
-
-            {/* Evaluation Criteria */}
-            <h2 className="text-xl font-bold mt-6">Evaluation Criteria</h2>
-            <table className="table-auto w-full">
-              <thead>
-                <tr>
-                  <th className="border px-4 py-2">Criteria</th>
-                  <th className="border px-4 py-2">Max Marks</th>
-                </tr>
-              </thead>
-              <tbody>
+            <div className="w-full md:w-80">
+              <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                Evaluation Criteria
+              </h3>
+              <div className="space-y-2">
                 {Object.entries(eventMetadata.evalCriteria).map(
                   ([key, value], index) => (
-                    <tr key={index}>
-                      <td className="border px-4 py-2">{key}</td>
-                      <td className="border px-4 py-2">{value}</td>
-                    </tr>
+                    <div
+                      key={index}
+                      className="flex justify-between items-center text-sm"
+                    >
+                      <span className="text-gray-600">{key}</span>
+                      <span className="font-semibold text-gray-900 bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
+                        {value} pts
+                      </span>
+                    </div>
                   ),
                 )}
-                <tr>
-                  <td className="border px-4 py-2 font-semibold">Total</td>
-                  <td className="border px-4 py-2 font-semibold">
+                <div className="pt-2 mt-2 border-t border-gray-100 flex justify-between items-center font-bold text-gray-900">
+                  <span>Total Maximum Marks</span>
+                  <span className="text-blue-600">
                     {Object.values(eventMetadata.evalCriteria).reduce(
                       (a, b) => a + b,
                       0,
-                    )}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                    )}{' '}
+                    pts
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 my-4 bg-white border overflow-x-auto">
-            <h1 className="text-2xl font-bold">Leaderboard</h1>
-            <table className="table-auto w-full mt-4">
-              <thead>
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+          <div className="p-6 border-b border-gray-100">
+            <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
                 <tr>
-                  {/* <th className="border px-4 py-2">District</th> */}
-                  <th className="border px-4 py-1">Students</th>
-                  {/* {eventMetadata.evalCriteria && Object.keys(eventMetadata.evalCriteria).map((criteria, index) => (
-                                        <th key={index} className="border px-4 py-2">{criteria}</th>
-                                    ))} */}
-                  <th className="border px-4 py-1">Judge Wise Total</th>
-                  <th className="border px-4 py-1">Total</th>
-                  <th className="border px-4 py-1">Comments</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Rank
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    District Information
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Group Members
+                  </th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Judge Wise
+                  </th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Total
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Comments
+                  </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="bg-white divide-y divide-gray-200">
                 {groups.map((group, index) => (
-                  <tr key={index}>
-                    {/* <td className="px-4 py-2 border font-bold">{group.district ?? "Unknown"}</td> */}
-                    <td className="px-4 py-2 border">
-                      {/* <p className="text-sm">{group.district ?? '-'}</p> */}
-                      {group.members.map((member, i) => (
-                        <p
-                          key={i}
-                          className="text-xs mt-2"
-                        >
-                          <span className="flex items-center gap-2 flex-col my-8">
-                            <span className="font-bold bg-gray-100 p-1 rounded-2xl pr-2">
-                              {member.id}
+                  <tr
+                    key={index}
+                    className="hover:bg-gray-50 transition-colors"
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span className="text-sm font-bold text-gray-900">
+                        #{index + 1}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="text-sm font-bold text-gray-900">
+                        {group.district ?? 'Unknown'}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {group.members.length} members
+                      </div>
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex flex-col gap-2">
+                        {group.members.map((member, i) => (
+                          <div
+                            key={i}
+                            className="flex flex-col sm:flex-row sm:items-center gap-2"
+                          >
+                            <span className="text-sm font-medium text-gray-900 whitespace-nowrap">
+                              {member.name}
                             </span>
-
+                            <div className="flex items-center gap-1">
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                                {member.id}
+                              </span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 text-center">
+                      <div className="flex flex-col gap-1">
+                        {Object.values(group.judgeWiseTotal).map(
+                          (total, idx) => (
                             <span
-                              className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
-                                member.ATTENDEE_STATUS === 'Attended'
-                                  ? 'bg-green-100 text-green-700 border border-green-300'
-                                  : 'bg-yellow-100 text-yellow-700 border border-yellow-300'
-                              }`}
+                              key={idx}
+                              className="text-xs font-bold text-gray-900 tabular-nums"
                             >
-                              {member.ATTENDEE_STATUS === 'Attended'
-                                ? 'Present'
-                                : 'Yet to Check In'}
+                              {parseFloat(total).toFixed(2)}
                             </span>
+                          ),
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 text-center whitespace-nowrap">
+                      <span className="text-sm font-black text-blue-600 tabular-nums">
+                        {parseFloat(group.overallTotal).toFixed(2)}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex flex-col gap-2 max-w-xs">
+                        {eventMetadata.judgeIdList.map((judgeId, i) => {
+                          const comment = group.comment[eventName][judgeId];
+                          if (!comment || comment === '-') return null;
+                          return (
+                            <div
+                              key={i}
+                              className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                            >
+                              <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
+                                Judge {i + 1}
+                              </p>
+                              <p className="text-xs text-gray-700 leading-relaxed">
+                                {comment}
+                              </p>
+                            </div>
+                          );
+                        })}
+                        {!eventMetadata.judgeIdList.some(
+                          (jid) =>
+                            group.comment[eventName][jid] &&
+                            group.comment[eventName][jid] !== '-',
+                        ) && (
+                          <span className="text-gray-400 italic text-xs">
+                            No comments
                           </span>
-                        </p>
-                      ))}
-                    </td>
-                    {/* {eventMetadata.evalCriteria && Object.keys(eventMetadata.evalCriteria).map((criteria, i1) => (
-                                            <td key={i1} className="px-4 py-2 border">
-                                                {eventMetadata.judgeIdList.map((judgeId, i2) => (
-                                                    <p key={i2} className="text-xs">{group.score[(eventName)][judgeId][criteria]}</p>
-                                                ))}
-                                            </td>
-                                        ))} */}
-                    <td className="px-4 py-2 border font-bold">
-                      {Object.values(group.judgeWiseTotal).map((total, i) => (
-                        <p
-                          key={i}
-                          className="text-xs"
-                        >
-                          {parseFloat(total).toFixed(2)}
-                        </p>
-                      ))}
-                    </td>
-                    <td className="px-4 py-2 border font-bold">
-                      {parseFloat(group.overallTotal).toFixed(2)}
-                    </td>
-                    <td className="px-4 py-2 border">
-                      {eventMetadata.judgeIdList.map((judgeId, i2) => (
-                        <p
-                          key={i2}
-                          className="text-xs"
-                        >
-                          {group.comment[eventName][judgeId]}
-                        </p>
-                      ))}
+                        )}
+                      </div>
                     </td>
                   </tr>
                 ))}
@@ -272,10 +319,13 @@ export default function GroupEventLeaderboardPage() {
           </div>
         </div>
       </div>
-    </>
+    </div>
   ) : (
-    <div className="flex h-screen items-center justify-center">
-      <p className="text-xl font-semibold">Loading...</p>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="flex flex-col items-center gap-4">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+        <p className="text-gray-500 font-medium">Loading leaderboard...</p>
+      </div>
     </div>
   );
 }

--- a/app/judge/group/leaderboard/page.js
+++ b/app/judge/group/leaderboard/page.js
@@ -44,8 +44,8 @@ export default function GroupEventLeaderboardPage() {
             };
           }
           acc[key].members.push({
-            name: participant.studentFullName || 'Unknown',
             id: participant.studentId || 'Unknown ID',
+            gender: participant.gender || '-',
           });
           return acc;
         }, {});
@@ -209,10 +209,10 @@ export default function GroupEventLeaderboardPage() {
                     Rank
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                    District Information
+                    Group Information
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                    Group Members
+                    Member Details
                   </th>
                   <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
                     Judge Wise
@@ -238,7 +238,7 @@ export default function GroupEventLeaderboardPage() {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm font-bold text-gray-900">
-                        {group.district ?? 'Unknown'}
+                        Group {index + 1}
                       </div>
                       <div className="text-xs text-gray-500">
                         {group.members.length} members
@@ -251,12 +251,12 @@ export default function GroupEventLeaderboardPage() {
                             key={i}
                             className="flex flex-col sm:flex-row sm:items-center gap-2"
                           >
-                            <span className="text-sm font-medium text-gray-900 whitespace-nowrap">
-                              {member.name}
-                            </span>
                             <div className="flex items-center gap-1">
                               <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
                                 {member.id}
+                              </span>
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-gray-50 text-gray-700 border border-gray-100">
+                                {member.gender}
                               </span>
                             </div>
                           </div>

--- a/app/judge/group/leaderboard/page.js
+++ b/app/judge/group/leaderboard/page.js
@@ -354,14 +354,12 @@ export default function GroupEventLeaderboardPage() {
                         key={i}
                         className="flex flex-col bg-gray-50 rounded p-2 text-xs border border-gray-100 flex-1 min-w-[100px]"
                       >
-                        <div className="flex justify-between items-center">
-                          <span className="text-gray-900 font-bold text-[10px]">
-                            {member.id}
-                          </span>
-                          <span className="text-gray-500 text-[10px]">
-                            {member.gender}
-                          </span>
-                        </div>
+                        <span className="text-gray-900 font-bold text-[10px] break-all">
+                          {member.id}
+                        </span>
+                        <span className="text-gray-500 text-[10px] text-right mt-1">
+                          {member.gender}
+                        </span>
                       </div>
                     ))}
                   </div>

--- a/app/judge/group/leaderboard/page.js
+++ b/app/judge/group/leaderboard/page.js
@@ -201,7 +201,7 @@ export default function GroupEventLeaderboardPage() {
             <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="hidden md:block overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
@@ -316,6 +316,107 @@ export default function GroupEventLeaderboardPage() {
                 ))}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile Card View */}
+          <div className="md:hidden flex flex-col gap-4 p-4 bg-gray-50">
+            {groups.map((group, index) => (
+              <div
+                key={index}
+                className="bg-white rounded-xl p-4 shadow-sm border border-gray-200"
+              >
+                <div className="flex justify-between items-start mb-3">
+                  <div className="flex items-center gap-2">
+                    <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
+                      #{index + 1}
+                    </span>
+                    <div>
+                      <h3 className="text-sm font-bold text-gray-900">
+                        Group {index + 1}
+                      </h3>
+                      <p className="text-xs text-gray-500">
+                        {group.members.length} members
+                      </p>
+                    </div>
+                  </div>
+                  <span className="text-lg font-black text-blue-600">
+                    {parseFloat(group.overallTotal).toFixed(2)}
+                  </span>
+                </div>
+
+                <div className="mb-4">
+                  <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
+                    Members
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {group.members.map((member, i) => (
+                      <div
+                        key={i}
+                        className="flex flex-col bg-gray-50 rounded p-2 text-xs border border-gray-100 flex-1 min-w-[100px]"
+                      >
+                        <div className="flex justify-between items-center">
+                          <span className="text-gray-900 font-bold text-[10px]">
+                            {member.id}
+                          </span>
+                          <span className="text-gray-500 text-[10px]">
+                            {member.gender}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="bg-gray-50 rounded-lg p-3 space-y-2">
+                  <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
+                    <span>Judge Scores</span>
+                    <span>Total</span>
+                  </div>
+                  {eventMetadata.judgeIdList.map((judgeId, i) => (
+                    <div
+                      key={i}
+                      className="flex justify-between items-center text-xs"
+                    >
+                      <span className="text-gray-600">Judge {i + 1}</span>
+                      <span className="font-bold text-gray-900">
+                        {parseFloat(group.judgeWiseTotal[judgeId] || 0).toFixed(
+                          2,
+                        )}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+
+                {eventMetadata.judgeIdList.some(
+                  (jid) =>
+                    group.comment[eventName][jid] &&
+                    group.comment[eventName][jid] !== '-',
+                ) && (
+                  <div className="mt-3 pt-3 border-t border-gray-100">
+                    <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
+                      Comments
+                    </p>
+                    <div className="space-y-2">
+                      {eventMetadata.judgeIdList.map((judgeId, i) => {
+                        const comment = group.comment[eventName][judgeId];
+                        if (!comment || comment === '-') return null;
+                        return (
+                          <div
+                            key={i}
+                            className="text-xs text-gray-600"
+                          >
+                            <span className="font-semibold text-gray-800">
+                              J{i + 1}:{' '}
+                            </span>{' '}
+                            {comment}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/app/judge/group/page.js
+++ b/app/judge/group/page.js
@@ -177,6 +177,7 @@ export default function JudgeGroupPage() {
                   key={index}
                   className="rounded-2xl px-4 py-1 bg-gray-100 border"
                 >
+                  <h2 className="text-xl font-bold mt-4">Group {index + 1}</h2>
                   <div className="flex flex-row justify-between pb-4">
                     <div className="flex flex-col justify-between">
                       {val.map((participant, index) => (
@@ -191,54 +192,11 @@ export default function JudgeGroupPage() {
                                   {participant.studentId}
                                 </h2>
                               </div>
-                              <p className="text-sm">
-                                Participating in{' '}
-                                <span className="font-bold">
-                                  {participant.registeredEvents.length}
-                                </span>{' '}
-                                event
-                                {participant.registeredEvents.length > 1
-                                  ? 's'
-                                  : ''}
-                                .
-                              </p>
-
-                              <span
-                                className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
-                                  participant.ATTENDEE_STATUS === 'Attended'
-                                    ? 'bg-green-100 text-green-700 border border-green-300'
-                                    : 'bg-yellow-100 text-yellow-700 border border-yellow-300'
-                                }`}
-                              >
-                                {participant.ATTENDEE_STATUS === 'Attended'
-                                  ? 'Present'
-                                  : 'Yet to Check In'}
-                              </span>
-
-                              {/* Other registered events (excluding current) */}
-                              {participant.registeredEvents.filter(
-                                (ev) => ev !== eventMetadata.name,
-                              ).length > 0 && (
-                                <p className="text-sm mb-3 text-gray-600">
-                                  Also participating in{' '}
-                                  <span className="px-2 py-0.5 rounded-full bg-violet-50 font-semibold text-violet-700 border-2 border-violet-300 text-xs">
-                                    {participant.registeredEvents
-                                      .filter((ev) => ev !== eventMetadata.name)
-                                      .join(', ')}
-                                  </span>
-                                </p>
-                              )}
-
                               <p className="text-xs">
-                                {participant.gender ?? '-'} -{' '}
-                                {participant.dateOfBirth ?? '-'}
-                              </p>
-                              <p className="text-xs rounded-2xl w-fit">
-                                {participant.studentGroup ?? '-'}
+                                {participant.gender ?? '-'}
                               </p>
                             </div>
                           </div>
-                          {/* <hr /> */}
                         </div>
                       ))}
                     </div>

--- a/app/judge/individual/leaderboard/page.js
+++ b/app/judge/individual/leaderboard/page.js
@@ -161,6 +161,7 @@ export default function EventLeaderboardIndiPage() {
                       key={index}
                       className="flex justify-between items-center text-sm"
                     >
+                      <span className="text-gray-600">{key}</span>
                       <span className="font-semibold text-gray-900 bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
                         {value} pts
                       </span>

--- a/app/judge/individual/leaderboard/page.js
+++ b/app/judge/individual/leaderboard/page.js
@@ -101,22 +101,24 @@ export default function EventLeaderboardIndiPage() {
     eventMetadata &&
     participants &&
     filteredParticipants ? (
-    <>
-      <div className="flex flex-col justify-center w-screen min-w-[95%] ml-auto mr-auto">
-        <div className="rounded-2xl p-4 m-2 bg-white border overflow-x-auto justify-between flex flex-col md:flex-row">
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <h1 className="text-2xl font-bold">Welcome, {user.name}</h1>
-            <p className="text-gray-700 mt-2">{user.email}</p>
+            <h1 className="text-2xl font-bold text-gray-900">
+              Welcome, {user.name}
+            </h1>
+            <p className="text-gray-500">{user.email}</p>
           </div>
-          <div className="flex flex-row mt-2 md:mt-0">
+          <div className="flex gap-3 w-full md:w-auto">
             <button
-              className="bg-[#fffece] text-[#2c350b] font-bold px-4 py-1 rounded-xl mr-2"
+              className="flex-1 md:flex-none bg-yellow-100 text-yellow-800 hover:bg-yellow-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => router.push('/judge/individual')}
             >
               Dashboard
             </button>
             <button
-              className="bg-[#ffcece] text-[#350b0b] font-bold px-4 py-1 rounded-xl"
+              className="flex-1 md:flex-none bg-red-100 text-red-800 hover:bg-red-200 font-semibold px-4 py-2 rounded-xl transition-colors"
               onClick={() => {
                 auth.signOut();
                 secureLocalStorage.clear();
@@ -128,176 +130,201 @@ export default function EventLeaderboardIndiPage() {
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 bg-white border overflow-x-auto">
-            <h1 className="text-xl font-bold">{eventMetadata.name}</h1>
-            <p className="text-md">{participants.length} Participants</p>
-            <div className="flex flex-row flex-wrap gap-1 mt-1">
-              {eventMetadata.group.map((group, index) => (
-                <p
-                  key={index}
-                  className="bg-gray-200 text-gray-800 font-semibold px-2 py-1 rounded-xl w-fit"
-                >
-                  {group}
-                </p>
-              ))}
+        <div className="bg-white rounded-2xl shadow-sm p-6 mb-6">
+          <div className="flex flex-col md:flex-row justify-between gap-6">
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                {eventMetadata.name}
+              </h2>
+              <p className="text-gray-500 mb-4">
+                {participants.length} Participants enrolled
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {eventMetadata.group.map((group, index) => (
+                  <span
+                    key={index}
+                    className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800 border border-gray-200"
+                  >
+                    {group}
+                  </span>
+                ))}
+              </div>
             </div>
-
-            {/* Evaluation Criteria */}
-            <h2 className="text-xl font-bold mt-6">Evaluation Criteria</h2>
-            <table className="table-auto w-full">
-              <thead>
-                <tr>
-                  <th className="border px-4 py-2">Criteria</th>
-                  <th className="border px-4 py-2">Max Marks</th>
-                </tr>
-              </thead>
-              <tbody>
+            <div className="w-full md:w-80">
+              <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                Evaluation Criteria
+              </h3>
+              <div className="space-y-2">
                 {Object.entries(eventMetadata.evalCriteria).map(
                   ([key, value], index) => (
-                    <tr key={index}>
-                      <td className="border px-4 py-2">{key}</td>
-                      <td className="border px-4 py-2">{value}</td>
-                    </tr>
+                    <div
+                      key={index}
+                      className="flex justify-between items-center text-sm"
+                    >
+                      <span className="text-gray-600">{key}</span>
+                      <span className="font-semibold text-gray-900 bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
+                        {value} pts
+                      </span>
+                    </div>
                   ),
                 )}
-                <tr>
-                  <td className="border px-4 py-2 font-semibold">Total</td>
-                  <td className="border px-4 py-2 font-semibold">
+                <div className="pt-2 mt-2 border-t border-gray-100 flex justify-between items-center font-bold text-gray-900">
+                  <span>Total Maximum Marks</span>
+                  <span className="text-blue-600">
                     {Object.values(eventMetadata.evalCriteria).reduce(
                       (a, b) => a + b,
                       0,
-                    )}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                    )}{' '}
+                    pts
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
-        <div className="flex flex-col justify-center w-fit min-w-[95%] ml-auto mr-auto">
-          <div className="rounded-2xl p-4 my-4 bg-white border overflow-x-auto">
-            <h1 className="text-2xl font-bold">Leaderboard</h1>
-            <table className="table-auto w-full mt-4">
-              <thead>
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+          <div className="p-6 border-b border-gray-100">
+            <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
                 <tr>
-                  <th className="border px-4 py-2">Student</th>
-                  {/* {eventMetadata.evalCriteria && Object.keys(eventMetadata.evalCriteria).map((criteria, index) => (
-                                        <th key={index} className="border px-4 py-2">{criteria}</th>
-                                    ))} */}
-                  <th className="border px-4 py-2">Judge Wise Total</th>
-                  <th className="border px-4 py-2">Total</th>
-                  <th className="border px-4 py-2">Comments</th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Rank
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Student Information
+                  </th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Judge Wise
+                  </th>
+                  <th className="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Total
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Comments
+                  </th>
                 </tr>
               </thead>
-              <tbody>
-                {filteredParticipants.map((row, index) => (
-                  <tr key={index}>
-                    <td
-                      className={
-                        'px-4 py-2 border max-w-40' +
-                        (row.substitute && row.substitute[eventMetadata.name]
-                          ? ' bg-[#ffcece]'
-                          : '')
-                      }
+              <tbody className="bg-white divide-y divide-gray-200">
+                {filteredParticipants.map((row, index) => {
+                  const isSubstituted =
+                    row.substitute && row.substitute[eventMetadata.name];
+                  return (
+                    <tr
+                      key={index}
+                      className={`hover:bg-gray-50 transition-colors ${isSubstituted ? 'bg-red-50/50' : ''}`}
                     >
-                      {row.substitute && row.substitute[eventMetadata.name] ? (
-                        <div>
-                          <p className="text-xs font-semibold text-[#32350b] rounded-2xl w-fit">
-                            Substituted Student - Original{' '}
-                            <span className="font-bold">{row.studentId}</span>
-                          </p>
-                          <p className="font-bold">
-                            {row.substitute[eventMetadata.name].newStudentName}
-                          </p>
-                          <p className="text-xs">
-                            {row.substitute[eventMetadata.name]
-                              .newStudentGender ?? '-'}{' '}
-                            -{' '}
-                            {row.substitute[eventMetadata.name].newStudentDOB ??
-                              '-'}
-                          </p>
-                          <p className="text-xs mt-2 font-bold bg-[#bad1ff] text-[#090e2d] p-1 px-2 rounded-2xl w-fit">
-                            {row.substitute[eventMetadata.name]
-                              .newStudentGroup ?? '-'}
-                          </p>
-                        </div>
-                      ) : (
-                        <div>
-                          <div className="flex flex-wrap items-center gap-1">
-                            <p className="text-xs font-bold bg-[#c4ffc2] text-[#07210d] p-1 px-2 rounded-2xl w-fit">
-                              {row.studentId ?? '-'}
-                            </p>
-
-                            <span
-                              className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${
-                                row.ATTENDEE_STATUS === 'Attended'
-                                  ? 'bg-green-100 text-green-700 border border-green-300'
-                                  : 'bg-yellow-100 text-yellow-700 border border-yellow-300'
-                              }`}
-                            >
-                              {row.ATTENDEE_STATUS === 'Attended'
-                                ? 'Present'
-                                : 'Yet to Check In'}
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className="text-sm font-bold text-gray-900">
+                          #{index + 1}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        {isSubstituted ? (
+                          <div className="flex flex-col">
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">
+                              SUBSTITUTE
                             </span>
-
-                            <p className="text-xs font-bold bg-[#bad1ff] text-[#090e2d] p-1 px-2 rounded-2xl w-fit">
-                              {row.studentGroup ?? '-'}
-                            </p>
+                            <span className="text-sm font-bold text-gray-900">
+                              {
+                                row.substitute[eventMetadata.name]
+                                  .newStudentName
+                              }
+                            </span>
+                            <span className="text-xs text-gray-500">
+                              Orig ID: {row.studentId}
+                            </span>
                           </div>
-                          <p className="px-2 text-xs pt-2">
-                            {row.gender ?? '-'} - {row.dateOfBirth ?? '-'}
-                          </p>
+                        ) : (
+                          <div className="flex flex-col">
+                            <span className="text-sm font-bold text-gray-900">
+                              {row.studentFullName ?? '-'}
+                            </span>
+                            <div className="flex flex-wrap gap-2 mt-1">
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                                {row.studentId}
+                              </span>
+                              <span
+                                className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border ${
+                                  row.ATTENDEE_STATUS === 'Attended'
+                                    ? 'bg-green-50 text-green-700 border-green-100'
+                                    : 'bg-yellow-50 text-yellow-700 border-yellow-100'
+                                }`}
+                              >
+                                {row.ATTENDEE_STATUS === 'Attended'
+                                  ? 'Present'
+                                  : 'Absent'}
+                              </span>
+                            </div>
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-6 py-4 text-center">
+                        <div className="flex flex-col gap-1">
+                          {Object.values(row.judgeWiseTotal).map(
+                            (total, idx) => (
+                              <span
+                                key={idx}
+                                className="text-xs font-bold text-gray-900 tabular-nums"
+                              >
+                                {parseFloat(total).toFixed(2)}
+                              </span>
+                            ),
+                          )}
                         </div>
-                      )}
-                    </td>
-                    {/* {eventMetadata.evalCriteria && Object.keys(eventMetadata.evalCriteria).map((criteria, i1) => (
-                                            <td key={i1} className="px-4 py-2 border">
-                                                {eventMetadata.judgeIdList.map((judgeId, i2) => (
-                                                    <p key={i2} className="text-xs">{row.score[(eventName)][judgeId][criteria]}</p>
-                                                ))}
-                                            </td>
-                                        ))} */}
-                    <td className="px-4 py-2 border font-bold">
-                      {Object.values(row.judgeWiseTotal).map((total, index) => (
-                        <p
-                          key={index}
-                          className="text-xs"
-                        >
-                          {parseFloat(total).toFixed(2)}
-                        </p>
-                      ))}
-                    </td>
-                    <td className="px-4 py-2 border font-bold">
-                      {parseFloat(row.overallTotal).toFixed(2)}
-                    </td>
-                    <td className="px-4 py-2 border">
-                      <div className="flex flex-col">
-                        {eventMetadata.judgeIdList.map((judgeId, i) => (
-                          <div
-                            key={i}
-                            className="flex flex-col"
-                          >
-                            <p className="text-xs">
-                              {row.comment[eventName][judgeId] == ''
-                                ? '-'
-                                : row.comment[eventName][judgeId]}
-                            </p>
-                          </div>
-                        ))}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td className="px-6 py-4 text-center whitespace-nowrap">
+                        <span className="text-sm font-black text-blue-600 tabular-nums">
+                          {parseFloat(row.overallTotal).toFixed(2)}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col gap-2 max-w-xs">
+                          {eventMetadata.judgeIdList.map((judgeId, i) => {
+                            const comment = row.comment[eventName][judgeId];
+                            if (!comment) return null;
+                            return (
+                              <div
+                                key={i}
+                                className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                              >
+                                <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
+                                  Judge {i + 1}
+                                </p>
+                                <p className="text-xs text-gray-700 leading-relaxed">
+                                  {comment}
+                                </p>
+                              </div>
+                            );
+                          })}
+                          {!eventMetadata.judgeIdList.some(
+                            (jid) => row.comment[eventName][jid],
+                          ) && (
+                            <span className="text-gray-400 italic text-xs">
+                              No comments
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
         </div>
       </div>
-    </>
+    </div>
   ) : (
-    <div className="flex h-screen items-center justify-center">
-      <p className="text-xl font-semibold">Loading...</p>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="flex flex-col items-center gap-4">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+        <p className="text-gray-500 font-medium">Loading leaderboard...</p>
+      </div>
     </div>
   );
 }

--- a/app/judge/individual/leaderboard/page.js
+++ b/app/judge/individual/leaderboard/page.js
@@ -161,7 +161,6 @@ export default function EventLeaderboardIndiPage() {
                       key={index}
                       className="flex justify-between items-center text-sm"
                     >
-                      <span className="text-gray-600">{key}</span>
                       <span className="font-semibold text-gray-900 bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
                         {value} pts
                       </span>
@@ -188,7 +187,7 @@ export default function EventLeaderboardIndiPage() {
             <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="hidden md:block overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
@@ -305,6 +304,110 @@ export default function EventLeaderboardIndiPage() {
                 })}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile Card View */}
+          <div className="md:hidden flex flex-col gap-4 p-4 bg-gray-50">
+            {filteredParticipants.map((row, index) => {
+              const isSubstituted =
+                row.substitute && row.substitute[eventMetadata.name];
+              return (
+                <div
+                  key={index}
+                  className={`bg-white rounded-xl p-4 shadow-sm border ${
+                    isSubstituted
+                      ? 'border-red-200 bg-red-50/10'
+                      : 'border-gray-200'
+                  }`}
+                >
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
+                        #{index + 1}
+                      </span>
+                      {isSubstituted ? (
+                        <div className="flex flex-col">
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">
+                            SUBSTITUTE
+                          </span>
+                          <div className="flex flex-wrap gap-2">
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                              {row.substitute[eventMetadata.name]
+                                .newStudentId || 'New ID'}
+                            </span>
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-gray-50 text-gray-700 border border-gray-100">
+                              {row.substitute[eventMetadata.name]
+                                .newStudentGender || '-'}
+                            </span>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex flex-col gap-1">
+                          <div className="flex flex-wrap gap-2">
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                              {row.studentId}
+                            </span>
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-gray-50 text-gray-700 border border-gray-100">
+                              {row.gender || '-'}
+                            </span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                    <span className="text-lg font-black text-blue-600">
+                      {parseFloat(row.overallTotal).toFixed(2)}
+                    </span>
+                  </div>
+
+                  <div className="bg-gray-50 rounded-lg p-3 space-y-2">
+                    <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
+                      <span>Judge Scores</span>
+                      <span>Total</span>
+                    </div>
+                    {eventMetadata.judgeIdList.map((judgeId, i) => (
+                      <div
+                        key={i}
+                        className="flex justify-between items-center text-xs"
+                      >
+                        <span className="text-gray-600">Judge {i + 1}</span>
+                        <span className="font-bold text-gray-900">
+                          {parseFloat(row.judgeWiseTotal[judgeId] || 0).toFixed(
+                            2,
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+
+                  {eventMetadata.judgeIdList.some(
+                    (jid) => row.comment[eventName][jid],
+                  ) && (
+                    <div className="mt-3 pt-3 border-t border-gray-100">
+                      <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
+                        Comments
+                      </p>
+                      <div className="space-y-2">
+                        {eventMetadata.judgeIdList.map((judgeId, i) => {
+                          const comment = row.comment[eventName][judgeId];
+                          if (!comment) return null;
+                          return (
+                            <div
+                              key={i}
+                              className="text-xs text-gray-600"
+                            >
+                              <span className="font-semibold text-gray-800">
+                                J{i + 1}:{' '}
+                              </span>{' '}
+                              {comment}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/app/judge/individual/leaderboard/page.js
+++ b/app/judge/individual/leaderboard/page.js
@@ -229,35 +229,25 @@ export default function EventLeaderboardIndiPage() {
                             <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">
                               SUBSTITUTE
                             </span>
-                            <span className="text-sm font-bold text-gray-900">
-                              {
-                                row.substitute[eventMetadata.name]
-                                  .newStudentName
-                              }
-                            </span>
-                            <span className="text-xs text-gray-500">
-                              Orig ID: {row.studentId}
-                            </span>
+                            <div className="flex flex-wrap gap-2">
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                                {row.substitute[eventMetadata.name]
+                                  .newStudentId || 'New ID'}
+                              </span>
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-gray-50 text-gray-700 border border-gray-100">
+                                {row.substitute[eventMetadata.name]
+                                  .newStudentGender || '-'}
+                              </span>
+                            </div>
                           </div>
                         ) : (
                           <div className="flex flex-col">
-                            <span className="text-sm font-bold text-gray-900">
-                              {row.studentFullName ?? '-'}
-                            </span>
-                            <div className="flex flex-wrap gap-2 mt-1">
+                            <div className="flex flex-wrap gap-2">
                               <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
                                 {row.studentId}
                               </span>
-                              <span
-                                className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border ${
-                                  row.ATTENDEE_STATUS === 'Attended'
-                                    ? 'bg-green-50 text-green-700 border-green-100'
-                                    : 'bg-yellow-50 text-yellow-700 border-yellow-100'
-                                }`}
-                              >
-                                {row.ATTENDEE_STATUS === 'Attended'
-                                  ? 'Present'
-                                  : 'Absent'}
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-gray-50 text-gray-700 border border-gray-100">
+                                {row.gender || '-'}
                               </span>
                             </div>
                           </div>

--- a/app/judge/individual/page.js
+++ b/app/judge/individual/page.js
@@ -355,27 +355,17 @@ export default function JudgePage() {
                     participant.substitute[eventMetadata.name] ? (
                       <div>
                         <p className="text-xs font-semibold text-[#32350b] rounded-2xl w-fit">
-                          Substituted Student - Original{' '}
-                          <span className="font-bold">
-                            {participant.studentId}
-                          </span>
+                          Substituted Student
                         </p>
                         <h2 className="text-xl font-bold">
                           {
                             participant.substitute[eventMetadata.name]
-                              .newStudentName
+                              .newStudentId
                           }
                         </h2>
                         <p className="text-xs">
                           {participant.substitute[eventMetadata.name]
                             .newStudentGender ?? '-'}{' '}
-                          -{' '}
-                          {participant.substitute[eventMetadata.name]
-                            .newStudentDOB ?? '-'}
-                        </p>
-                        <p className="text-xs mt-2 font-bold bg-[#bad1ff] text-[#090e2d] p-1 px-2 rounded-2xl w-fit">
-                          {participant.substitute[eventMetadata.name]
-                            .newStudentGroup ?? '-'}
                         </p>
                       </div>
                     ) : (
@@ -385,61 +375,8 @@ export default function JudgePage() {
                             {participant.studentId}
                           </h2>
                         </div>
-                        <p className="text-sm">
-                          Participating in{' '}
-                          <span className="font-bold">
-                            {participant.registeredEvents.length}
-                          </span>{' '}
-                          event
-                          {participant.registeredEvents.length > 1 ? 's' : ''}.
-                        </p>
-
-                        <span
-                          className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
-                            participant.ATTENDEE_STATUS === 'Attended'
-                              ? 'bg-green-100 text-green-700 border border-green-300'
-                              : 'bg-yellow-100 text-yellow-700 border border-yellow-300'
-                          }`}
-                        >
-                          {participant.ATTENDEE_STATUS === 'Attended'
-                            ? 'Present'
-                            : 'Yet to Check In'}
-                        </span>
-
-                        {/* Other registered events (excluding current) */}
-                        {participant.registeredEvents.filter(
-                          (ev) => ev !== eventMetadata.name,
-                        ).length > 0 && (
-                          <div className="text-sm mb-3 text-gray-600">
-                            <span className="mr-1">Also participating in</span>
-                            <span className="inline-flex flex-wrap gap-1">
-                              {participant.registeredEvents
-                                .filter((ev) => ev !== eventMetadata.name)
-                                .map((ev, i) => (
-                                  <span
-                                    key={i}
-                                    className="px-2 py-0.5 rounded-full bg-violet-50 font-semibold text-violet-700 border-2 border-violet-300 text-xs"
-                                  >
-                                    {ev}
-                                  </span>
-                                ))}
-                            </span>
-                          </div>
-                        )}
-
-                        {participant.registeredEvents.some((x) =>
-                          x.includes('GROUP'),
-                        ) && (
-                          <p className="text-xs">
-                            Also in a group event. Please evaluate first.
-                          </p>
-                        )}
                         <p className="text-xs text-gray-700">
-                          {participant.gender ?? '-'} -{' '}
-                          {participant.dateOfBirth ?? '-'}
-                        </p>
-                        <p className="text-xs mt-2 font-bold bg-[#bad1ff] text-[#090e2d] p-1 px-2 rounded-2xl w-fit">
-                          {participant.studentGroup ?? '-'}
+                          {participant.gender ?? '-'}
                         </p>
                       </div>
                     )}


### PR DESCRIPTION
## Overview
updated the Individual and Group leaderboard pages for Admin and Judge.the focus was to match the new admin dashboard look and make sure everything works well on mobile.

## whats Changed
- switched old tables to simple card-style layouts
- made layouts responsive for smaller screens
- cleaned upspacing, fonts,nd colors to match the admin panel
- improved how judge comments and group members are shown
- better loading state with a centered spinner

## files Updated
- app/admin/event/individual/page.js  
- app/admin/event/group/page.js  
- app/judge/individual/leaderboard/page.js  
- app/judge/group/leaderboard/page.js  

## Screenshots for reference
Admin
<img width="1141" height="777" alt="Admin" src="https://github.com/user-attachments/assets/2dcd0265-11b6-4511-a5a3-4ea79b9983ca" />

Judge
<img width="1198" height="782" alt="Judge" src="https://github.com/user-attachments/assets/c4ce86e1-4cf5-44a6-8285-fff2fa16b9fc" />

Individual judge
<img width="1266" height="684" alt="Indi judge" src="https://github.com/user-attachments/assets/5619ae3e-0349-401a-b7db-9e8841dce03e" />

Closes #69
CC: @Ashrockzzz2003 