### PR TITLE
Highlight Top 5 ties in admin event views

### DIFF
--- a/app/_util/tieDetection.js
+++ b/app/_util/tieDetection.js
@@ -1,0 +1,113 @@
+const TOP_CUTOFF_RANK = 5;
+
+const normalizeScore = (score) => Number.parseFloat(score || 0).toFixed(2);
+
+export const formatTieSummary = (tie) => {
+  if (!tie) return '';
+
+  return `Top ${tie.cutoffRank} tie: ranks ${tie.rankStart}-${tie.rankEnd} share ${tie.score} pts`;
+};
+
+const getScoreTotal = (score, eventName, judgeIds, criteriaList) => {
+  return criteriaList.reduce((criteriaTotal, criteria) => {
+    const judgeTotal = judgeIds.reduce((total, judgeId) => {
+      return (
+        total + Number.parseFloat(score?.[eventName]?.[judgeId]?.[criteria] ?? 0)
+      );
+    }, 0);
+
+    return criteriaTotal + judgeTotal;
+  }, 0);
+};
+
+export const findTopCutoffTie = (
+  entries,
+  { cutoffRank = TOP_CUTOFF_RANK, getId = (entry) => entry.id } = {},
+) => {
+  if (!entries || entries.length <= cutoffRank) return null;
+
+  const sortedEntries = [...entries].sort(
+    (a, b) => b.overallTotal - a.overallTotal,
+  );
+  const cutoffScore = normalizeScore(sortedEntries[cutoffRank - 1].overallTotal);
+  const nextScore = normalizeScore(sortedEntries[cutoffRank].overallTotal);
+
+  if (cutoffScore !== nextScore) return null;
+
+  const rankStartIndex = sortedEntries.findIndex(
+    (entry) => normalizeScore(entry.overallTotal) === cutoffScore,
+  );
+
+  let rankEndIndex = rankStartIndex;
+  while (
+    rankEndIndex + 1 < sortedEntries.length &&
+    normalizeScore(sortedEntries[rankEndIndex + 1].overallTotal) === cutoffScore
+  ) {
+    rankEndIndex += 1;
+  }
+
+  const tiedEntries = sortedEntries.slice(rankStartIndex, rankEndIndex + 1);
+
+  return {
+    cutoffRank,
+    rankStart: rankStartIndex + 1,
+    rankEnd: rankEndIndex + 1,
+    score: cutoffScore,
+    ids: new Set(tiedEntries.map(getId)),
+    tiedEntries,
+  };
+};
+
+export const calculateIndividualTopCutoffTie = (
+  participants,
+  eventMetadata,
+  eventName = eventMetadata?.name,
+) => {
+  if (!participants || !eventMetadata || !eventName) return null;
+
+  const judgeIds = eventMetadata.judgeIdList || [];
+  const criteriaList = Object.keys(eventMetadata.evalCriteria || {});
+  const entries = participants.map((participant) => ({
+    id: participant.studentId,
+    overallTotal:
+      participant.overallTotal ??
+      getScoreTotal(participant.score, eventName, judgeIds, criteriaList),
+  }));
+
+  return findTopCutoffTie(entries);
+};
+
+export const calculateGroupTopCutoffTie = (
+  participantsOrGroups,
+  eventMetadata,
+  eventName = eventMetadata?.name,
+) => {
+  if (!participantsOrGroups || !eventMetadata || !eventName) return null;
+
+  const judgeIds = eventMetadata.judgeIdList || [];
+  const criteriaList = Object.keys(eventMetadata.evalCriteria || {});
+  const groupedEntries = participantsOrGroups.reduce(
+    (groups, participantOrGroup) => {
+      const district = participantOrGroup.district || 'Unknown';
+
+      if (!groups[district]) {
+        groups[district] = {
+          id: district,
+          overallTotal:
+            participantOrGroup.overallTotal ??
+            getScoreTotal(
+              participantOrGroup.score,
+              eventName,
+              judgeIds,
+              criteriaList,
+            ),
+        };
+      }
+
+      return groups;
+    },
+    {},
+  );
+
+  return findTopCutoffTie(Object.values(groupedEntries));
+};

--- a/app/_util/tieDetection.js
+++ b/app/_util/tieDetection.js
@@ -12,7 +12,8 @@ const getScoreTotal = (score, eventName, judgeIds, criteriaList) => {
   return criteriaList.reduce((criteriaTotal, criteria) => {
     const judgeTotal = judgeIds.reduce((total, judgeId) => {
       return (
-        total + Number.parseFloat(score?.[eventName]?.[judgeId]?.[criteria] ?? 0)
+        total +
+        Number.parseFloat(score?.[eventName]?.[judgeId]?.[criteria] ?? 0)
       );
     }, 0);
 
@@ -29,7 +30,9 @@ export const findTopCutoffTie = (
   const sortedEntries = [...entries].sort(
     (a, b) => b.overallTotal - a.overallTotal,
   );
-  const cutoffScore = normalizeScore(sortedEntries[cutoffRank - 1].overallTotal);
+  const cutoffScore = normalizeScore(
+    sortedEntries[cutoffRank - 1].overallTotal,
+  );
   const nextScore = normalizeScore(sortedEntries[cutoffRank].overallTotal);
 
   if (cutoffScore !== nextScore) return null;

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -633,80 +633,86 @@ export default function GroupEventLeaderboardPage() {
                           ))}
                         </div>
                       </td>
-                    {eventMetadata.evalCriteria &&
-                      Object.keys(eventMetadata.evalCriteria).map(
-                        (criteria, i1) => (
-                          <td
-                            key={i1}
-                            className="px-2 py-4 text-center"
-                          >
-                            <div className="flex flex-col gap-1">
-                              {eventMetadata.judgeIdList.map((judgeId, i2) => (
-                                <span
-                                  key={i2}
-                                  className="text-xs font-medium text-gray-600 tabular-nums"
-                                >
-                                  {group.score[eventName][judgeId][criteria]}
-                                </span>
-                              ))}
-                            </div>
-                          </td>
-                        ),
-                      )}
-                    <td className="px-6 py-4 text-center">
-                      <div className="flex flex-col gap-1 items-center">
-                        {eventMetadata.judgeIdList.map((judgeId, idx) => (
-                          <div
-                            key={idx}
-                            className="flex items-center gap-2 justify-between w-16"
-                          >
-                            <span className="text-[10px] text-gray-400 font-medium">
-                              J{idx + 1}
-                            </span>
-                            <span className="text-xs font-bold text-gray-900 tabular-nums text-right">
-                              {parseFloat(
-                                group.judgeWiseTotal[judgeId] || 0,
-                              ).toFixed(2)}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 text-center whitespace-nowrap">
-                      <span className="text-sm font-black text-blue-600 tabular-nums">
-                        {parseFloat(group.overallTotal).toFixed(2)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="flex flex-col gap-2">
-                        {eventMetadata.judgeIdList.map((judgeId, i) => {
-                          const comment = group.comment[eventName][judgeId];
-                          if (!comment || comment === '-') return null;
-                          return (
-                            <div
-                              key={i}
-                              className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                      {eventMetadata.evalCriteria &&
+                        Object.keys(eventMetadata.evalCriteria).map(
+                          (criteria, i1) => (
+                            <td
+                              key={i1}
+                              className="px-2 py-4 text-center"
                             >
-                              <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
-                                Judge {i + 1}
-                              </p>
-                              <p className="text-xs text-gray-700 leading-relaxed whitespace-normal">
-                                {comment}
-                              </p>
-                            </div>
-                          );
-                        })}
-                        {!eventMetadata.judgeIdList.some(
-                          (jid) =>
-                            group.comment[eventName][jid] &&
-                            group.comment[eventName][jid] !== '-',
-                        ) && (
-                          <span className="text-gray-400 italic text-xs">
-                            No comments
-                          </span>
+                              <div className="flex flex-col gap-1">
+                                {eventMetadata.judgeIdList.map(
+                                  (judgeId, i2) => (
+                                    <span
+                                      key={i2}
+                                      className="text-xs font-medium text-gray-600 tabular-nums"
+                                    >
+                                      {
+                                        group.score[eventName][judgeId][
+                                          criteria
+                                        ]
+                                      }
+                                    </span>
+                                  ),
+                                )}
+                              </div>
+                            </td>
+                          ),
                         )}
-                      </div>
-                    </td>
+                      <td className="px-6 py-4 text-center">
+                        <div className="flex flex-col gap-1 items-center">
+                          {eventMetadata.judgeIdList.map((judgeId, idx) => (
+                            <div
+                              key={idx}
+                              className="flex items-center gap-2 justify-between w-16"
+                            >
+                              <span className="text-[10px] text-gray-400 font-medium">
+                                J{idx + 1}
+                              </span>
+                              <span className="text-xs font-bold text-gray-900 tabular-nums text-right">
+                                {parseFloat(
+                                  group.judgeWiseTotal[judgeId] || 0,
+                                ).toFixed(2)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-center whitespace-nowrap">
+                        <span className="text-sm font-black text-blue-600 tabular-nums">
+                          {parseFloat(group.overallTotal).toFixed(2)}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col gap-2">
+                          {eventMetadata.judgeIdList.map((judgeId, i) => {
+                            const comment = group.comment[eventName][judgeId];
+                            if (!comment || comment === '-') return null;
+                            return (
+                              <div
+                                key={i}
+                                className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                              >
+                                <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
+                                  Judge {i + 1}
+                                </p>
+                                <p className="text-xs text-gray-700 leading-relaxed whitespace-normal">
+                                  {comment}
+                                </p>
+                              </div>
+                            );
+                          })}
+                          {!eventMetadata.judgeIdList.some(
+                            (jid) =>
+                              group.comment[eventName][jid] &&
+                              group.comment[eventName][jid] !== '-',
+                          ) && (
+                            <span className="text-gray-400 italic text-xs">
+                              No comments
+                            </span>
+                          )}
+                        </div>
+                      </td>
                     </tr>
                   );
                 })}
@@ -749,86 +755,88 @@ export default function GroupEventLeaderboardPage() {
                     </span>
                   </div>
 
-                <div className="mb-4">
-                  <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
-                    Members
-                  </p>
-                  <div className="flex flex-wrap gap-2">
-                    {group.members.map((member, i) => (
+                  <div className="mb-4">
+                    <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
+                      Members
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {group.members.map((member, i) => (
+                        <div
+                          key={i}
+                          className="flex flex-col bg-gray-50 rounded p-2 text-xs border border-gray-100 flex-1 min-w-[120px]"
+                        >
+                          <span className="font-medium text-gray-900 truncate">
+                            {member.name}
+                          </span>
+                          <div className="flex justify-between mt-1 items-center">
+                            <span className="text-gray-500 text-[10px]">
+                              {member.id}
+                            </span>
+                            <span
+                              className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold border ${
+                                member.ATTENDEE_STATUS === 'Attended'
+                                  ? 'bg-green-50 text-green-700 border-green-100'
+                                  : 'bg-yellow-50 text-yellow-700 border-yellow-100'
+                              }`}
+                            >
+                              {member.ATTENDEE_STATUS === 'Attended'
+                                ? 'P'
+                                : 'A'}
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="bg-gray-50 rounded-lg p-3 space-y-2">
+                    <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
+                      <span>Judge Scores</span>
+                      <span>Total</span>
+                    </div>
+                    {eventMetadata.judgeIdList.map((judgeId, i) => (
                       <div
                         key={i}
-                        className="flex flex-col bg-gray-50 rounded p-2 text-xs border border-gray-100 flex-1 min-w-[120px]"
+                        className="flex justify-between items-center text-xs"
                       >
-                        <span className="font-medium text-gray-900 truncate">
-                          {member.name}
+                        <span className="text-gray-600">Judge {i + 1}</span>
+                        <span className="font-bold text-gray-900">
+                          {parseFloat(
+                            group.judgeWiseTotal[judgeId] || 0,
+                          ).toFixed(2)}
                         </span>
-                        <div className="flex justify-between mt-1 items-center">
-                          <span className="text-gray-500 text-[10px]">
-                            {member.id}
-                          </span>
-                          <span
-                            className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold border ${
-                              member.ATTENDEE_STATUS === 'Attended'
-                                ? 'bg-green-50 text-green-700 border-green-100'
-                                : 'bg-yellow-50 text-yellow-700 border-yellow-100'
-                            }`}
-                          >
-                            {member.ATTENDEE_STATUS === 'Attended' ? 'P' : 'A'}
-                          </span>
-                        </div>
                       </div>
                     ))}
                   </div>
-                </div>
 
-                <div className="bg-gray-50 rounded-lg p-3 space-y-2">
-                  <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
-                    <span>Judge Scores</span>
-                    <span>Total</span>
-                  </div>
-                  {eventMetadata.judgeIdList.map((judgeId, i) => (
-                    <div
-                      key={i}
-                      className="flex justify-between items-center text-xs"
-                    >
-                      <span className="text-gray-600">Judge {i + 1}</span>
-                      <span className="font-bold text-gray-900">
-                        {parseFloat(group.judgeWiseTotal[judgeId] || 0).toFixed(
-                          2,
-                        )}
-                      </span>
+                  {eventMetadata.judgeIdList.some(
+                    (jid) =>
+                      group.comment[eventName][jid] &&
+                      group.comment[eventName][jid] !== '-',
+                  ) && (
+                    <div className="mt-3 pt-3 border-t border-gray-100">
+                      <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
+                        Comments
+                      </p>
+                      <div className="space-y-2">
+                        {eventMetadata.judgeIdList.map((judgeId, i) => {
+                          const comment = group.comment[eventName][judgeId];
+                          if (!comment || comment === '-') return null;
+                          return (
+                            <div
+                              key={i}
+                              className="text-xs text-gray-600"
+                            >
+                              <span className="font-semibold text-gray-800">
+                                J{i + 1}:{' '}
+                              </span>{' '}
+                              {comment}
+                            </div>
+                          );
+                        })}
+                      </div>
                     </div>
-                  ))}
-                </div>
-
-                {eventMetadata.judgeIdList.some(
-                  (jid) =>
-                    group.comment[eventName][jid] &&
-                    group.comment[eventName][jid] !== '-',
-                ) && (
-                  <div className="mt-3 pt-3 border-t border-gray-100">
-                    <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
-                      Comments
-                    </p>
-                    <div className="space-y-2">
-                      {eventMetadata.judgeIdList.map((judgeId, i) => {
-                        const comment = group.comment[eventName][judgeId];
-                        if (!comment || comment === '-') return null;
-                        return (
-                          <div
-                            key={i}
-                            className="text-xs text-gray-600"
-                          >
-                            <span className="font-semibold text-gray-800">
-                              J{i + 1}:{' '}
-                            </span>{' '}
-                            {comment}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
+                  )}
                 </div>
               );
             })}

--- a/app/admin/event/group/page.js
+++ b/app/admin/event/group/page.js
@@ -6,6 +6,10 @@ import { useEffect, useState } from 'react';
 import secureLocalStorage from 'react-secure-storage';
 import { getJudgeEventData } from '@/app/_util/data';
 import { auth } from '@/app/_util/initApp';
+import {
+  calculateGroupTopCutoffTie,
+  formatTieSummary,
+} from '@/app/_util/tieDetection';
 
 export default function GroupEventLeaderboardPage() {
   const router = useRouter();
@@ -15,6 +19,7 @@ export default function GroupEventLeaderboardPage() {
   const [eventMetadata, setEventMetadata] = useState(null);
   const [groups, setGroups] = useState(null);
   const [orderedJudges, setOrderedJudges] = useState([]);
+  const [topCutoffTie, setTopCutoffTie] = useState(null);
 
   const searchParams = useSearchParams();
 
@@ -114,6 +119,9 @@ export default function GroupEventLeaderboardPage() {
 
           setEventMetadata(_data[1]);
           setGroups(groups);
+          setTopCutoffTie(
+            calculateGroupTopCutoffTie(groups, _data[1], _eventName),
+          );
         })
         .catch((err) => {
           console.error(err);
@@ -460,6 +468,24 @@ export default function GroupEventLeaderboardPage() {
           </div>
         </div>
 
+        {topCutoffTie && (
+          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 justify-between">
+              <div>
+                <h3 className="text-sm font-bold text-amber-900">
+                  Top 5 tie needs review
+                </h3>
+                <p className="text-sm text-amber-800">
+                  {formatTieSummary(topCutoffTie)}.
+                </p>
+              </div>
+              <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-900 border border-amber-200">
+                Tie alert
+              </span>
+            </div>
+          </div>
+        )}
+
         <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
           <div className="p-6 border-b border-gray-100 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
             <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
@@ -548,54 +574,65 @@ export default function GroupEventLeaderboardPage() {
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
-                {groups.map((group, index) => (
-                  <tr
-                    key={index}
-                    className="hover:bg-gray-50 transition-colors"
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className="text-sm font-bold text-gray-900">
-                        #{index + 1}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-bold text-gray-900">
-                        {group.district}
-                      </div>
-                      <div className="text-xs text-gray-500">
-                        {group.members.length} members
-                      </div>
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="flex flex-col gap-2">
-                        {group.members.map((member, i) => (
-                          <div
-                            key={i}
-                            className="flex flex-col sm:flex-row sm:items-center gap-2"
-                          >
-                            <span className="text-sm font-medium text-gray-900 whitespace-nowrap">
-                              {member.name}
+                {groups.map((group, index) => {
+                  const isTopCutoffTie = topCutoffTie?.ids.has(
+                    group.district || 'Unknown',
+                  );
+                  return (
+                    <tr
+                      key={index}
+                      className={`hover:bg-gray-50 transition-colors ${isTopCutoffTie ? 'bg-amber-50/80' : ''}`}
+                    >
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex flex-col gap-1">
+                          <span className="text-sm font-bold text-gray-900">
+                            #{index + 1}
+                          </span>
+                          {isTopCutoffTie && (
+                            <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-900 border border-amber-200">
+                              TOP 5 TIE
                             </span>
-                            <div className="flex items-center gap-1">
-                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
-                                {member.id}
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-bold text-gray-900">
+                          {group.district}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {group.members.length} members
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col gap-2">
+                          {group.members.map((member, i) => (
+                            <div
+                              key={i}
+                              className="flex flex-col sm:flex-row sm:items-center gap-2"
+                            >
+                              <span className="text-sm font-medium text-gray-900 whitespace-nowrap">
+                                {member.name}
                               </span>
-                              <span
-                                className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border ${
-                                  member.ATTENDEE_STATUS === 'Attended'
-                                    ? 'bg-green-50 text-green-700 border-green-100'
-                                    : 'bg-yellow-50 text-yellow-700 border-yellow-100'
-                                }`}
-                              >
-                                {member.ATTENDEE_STATUS === 'Attended'
-                                  ? 'P'
-                                  : 'A'}
-                              </span>
+                              <div className="flex items-center gap-1">
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                                  {member.id}
+                                </span>
+                                <span
+                                  className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold border ${
+                                    member.ATTENDEE_STATUS === 'Attended'
+                                      ? 'bg-green-50 text-green-700 border-green-100'
+                                      : 'bg-yellow-50 text-yellow-700 border-yellow-100'
+                                  }`}
+                                >
+                                  {member.ATTENDEE_STATUS === 'Attended'
+                                    ? 'P'
+                                    : 'A'}
+                                </span>
+                              </div>
                             </div>
-                          </div>
-                        ))}
-                      </div>
-                    </td>
+                          ))}
+                        </div>
+                      </td>
                     {eventMetadata.evalCriteria &&
                       Object.keys(eventMetadata.evalCriteria).map(
                         (criteria, i1) => (
@@ -670,37 +707,47 @@ export default function GroupEventLeaderboardPage() {
                         )}
                       </div>
                     </td>
-                  </tr>
-                ))}
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
 
           {/* Mobile Card View */}
           <div className="md:hidden flex flex-col gap-4 p-4 bg-gray-50">
-            {groups.map((group, index) => (
-              <div
-                key={index}
-                className="bg-white rounded-xl p-4 shadow-sm border border-gray-200"
-              >
-                <div className="flex justify-between items-start mb-3">
-                  <div className="flex items-center gap-2">
-                    <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
-                      #{index + 1}
-                    </span>
-                    <div>
-                      <h3 className="text-sm font-bold text-gray-900">
-                        {group.district ?? 'Unknown'}
-                      </h3>
-                      <p className="text-xs text-gray-500">
-                        {group.members.length} members
-                      </p>
+            {groups.map((group, index) => {
+              const isTopCutoffTie = topCutoffTie?.ids.has(
+                group.district || 'Unknown',
+              );
+              return (
+                <div
+                  key={index}
+                  className={`bg-white rounded-xl p-4 shadow-sm border ${isTopCutoffTie ? 'border-amber-200 bg-amber-50/80' : 'border-gray-200'}`}
+                >
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
+                        #{index + 1}
+                      </span>
+                      {isTopCutoffTie && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-900 border border-amber-200">
+                          TOP 5 TIE
+                        </span>
+                      )}
+                      <div>
+                        <h3 className="text-sm font-bold text-gray-900">
+                          {group.district ?? 'Unknown'}
+                        </h3>
+                        <p className="text-xs text-gray-500">
+                          {group.members.length} members
+                        </p>
+                      </div>
                     </div>
+                    <span className="text-lg font-black text-blue-600">
+                      {parseFloat(group.overallTotal).toFixed(2)}
+                    </span>
                   </div>
-                  <span className="text-lg font-black text-blue-600">
-                    {parseFloat(group.overallTotal).toFixed(2)}
-                  </span>
-                </div>
 
                 <div className="mb-4">
                   <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
@@ -782,8 +829,9 @@ export default function GroupEventLeaderboardPage() {
                     </div>
                   </div>
                 )}
-              </div>
-            ))}
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/app/admin/event/individual/page.js
+++ b/app/admin/event/individual/page.js
@@ -6,6 +6,10 @@ import { useEffect, useState } from 'react';
 import secureLocalStorage from 'react-secure-storage';
 import { getJudgeEventData } from '@/app/_util/data';
 import { auth } from '@/app/_util/initApp';
+import {
+  calculateIndividualTopCutoffTie,
+  formatTieSummary,
+} from '@/app/_util/tieDetection';
 
 export default function EventLeaderboardIndiPage() {
   const router = useRouter();
@@ -16,6 +20,7 @@ export default function EventLeaderboardIndiPage() {
   const [filteredParticipants, setFilteredParticipants] = useState(null);
 
   const [orderedJudges, setOrderedJudges] = useState([]);
+  const [topCutoffTie, setTopCutoffTie] = useState(null);
 
   const searchParams = useSearchParams();
 
@@ -94,6 +99,9 @@ export default function EventLeaderboardIndiPage() {
           _data[0].sort((a, b) => b.overallTotal - a.overallTotal);
 
           setEventMetadata(_data[1]);
+          setTopCutoffTie(
+            calculateIndividualTopCutoffTie(_data[0], _data[1], _eventName),
+          );
 
           const db = getFirestore();
           const mappingSnap = await getDoc(
@@ -455,6 +463,24 @@ export default function EventLeaderboardIndiPage() {
           </div>
         </div>
 
+        {topCutoffTie && (
+          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 justify-between">
+              <div>
+                <h3 className="text-sm font-bold text-amber-900">
+                  Top 5 tie needs review
+                </h3>
+                <p className="text-sm text-amber-800">
+                  {formatTieSummary(topCutoffTie)}.
+                </p>
+              </div>
+              <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-900 border border-amber-200">
+                Tie alert
+              </span>
+            </div>
+          </div>
+        )}
+
         {/* Leaderboard Card */}
         <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
           <div className="p-6 border-b border-gray-100 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
@@ -547,15 +573,23 @@ export default function EventLeaderboardIndiPage() {
                 {filteredParticipants.map((row, index) => {
                   const isSubstituted =
                     row.substitute && row.substitute[eventMetadata.name];
+                  const isTopCutoffTie = topCutoffTie?.ids.has(row.studentId);
                   return (
                     <tr
                       key={index}
-                      className={`hover:bg-gray-50 transition-colors ${isSubstituted ? 'bg-red-50/50' : ''}`}
+                      className={`hover:bg-gray-50 transition-colors ${isTopCutoffTie ? 'bg-amber-50/80' : isSubstituted ? 'bg-red-50/50' : ''}`}
                     >
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <span className="text-sm font-bold text-gray-900">
-                          #{index + 1}
-                        </span>
+                        <div className="flex flex-col gap-1">
+                          <span className="text-sm font-bold text-gray-900">
+                            #{index + 1}
+                          </span>
+                          {isTopCutoffTie && (
+                            <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-900 border border-amber-200">
+                              TOP 5 TIE
+                            </span>
+                          )}
+                        </div>
                       </td>
                       <td className="px-6 py-4">
                         {isSubstituted ? (
@@ -691,13 +725,16 @@ export default function EventLeaderboardIndiPage() {
             {filteredParticipants.map((row, index) => {
               const isSubstituted =
                 row.substitute && row.substitute[eventMetadata.name];
+              const isTopCutoffTie = topCutoffTie?.ids.has(row.studentId);
               return (
                 <div
                   key={index}
                   className={`bg-white rounded-xl p-4 shadow-sm border ${
-                    isSubstituted
-                      ? 'border-red-200 bg-red-50/10'
-                      : 'border-gray-200'
+                    isTopCutoffTie
+                      ? 'border-amber-200 bg-amber-50/80'
+                      : isSubstituted
+                        ? 'border-red-200 bg-red-50/10'
+                        : 'border-gray-200'
                   }`}
                 >
                   <div className="flex justify-between items-start mb-3">
@@ -705,6 +742,11 @@ export default function EventLeaderboardIndiPage() {
                       <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
                         #{index + 1}
                       </span>
+                      {isTopCutoffTie && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-900 border border-amber-200">
+                          TOP 5 TIE
+                        </span>
+                      )}
                       {isSubstituted ? (
                         <div className="flex flex-col">
                           <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">

--- a/app/admin/event/page.js
+++ b/app/admin/event/page.js
@@ -15,6 +15,11 @@ import {
   updateCrieria,
 } from '@/app/_util/data';
 import { auth } from '@/app/_util/initApp';
+import {
+  calculateGroupTopCutoffTie,
+  calculateIndividualTopCutoffTie,
+  formatTieSummary,
+} from '@/app/_util/tieDetection';
 
 export default function ManageEvents() {
   const router = useRouter();
@@ -32,6 +37,7 @@ export default function ManageEvents() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [copiedJudge, setCopiedJudge] = useState(null);
+  const [eventTieAlerts, setEventTieAlerts] = useState({});
 
   useEffect(() => {
     if (!secureLocalStorage.getItem('user')) {
@@ -50,6 +56,32 @@ export default function ManageEvents() {
       setGroups(_data[1]);
 
       isLoading && setIsLoading(false);
+
+      Promise.all(
+        _data[0].map(async (event) => {
+          try {
+            const result = await getJudgeEventData(event.name);
+            if (!result || result.length !== 2) return [event.name, null];
+
+            const tie = event.name.includes('GROUP')
+              ? calculateGroupTopCutoffTie(result[0], result[1], event.name)
+              : calculateIndividualTopCutoffTie(
+                  result[0],
+                  result[1],
+                  event.name,
+                );
+
+            return [event.name, tie];
+          } catch (err) {
+            console.error(`Unable to check ties for ${event.name}:`, err);
+            return [event.name, null];
+          }
+        }),
+      ).then((alerts) => {
+        setEventTieAlerts(
+          Object.fromEntries(alerts.filter(([, tie]) => Boolean(tie))),
+        );
+      });
     });
   }, [router, isLoading]);
 
@@ -418,6 +450,16 @@ export default function ManageEvents() {
                             <span className="text-sm font-bold text-gray-900">
                               {event.name}
                             </span>
+                            {eventTieAlerts[event.name] && (
+                              <span
+                                className="inline-flex w-fit items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-amber-100 text-amber-900 border border-amber-200"
+                                title={formatTieSummary(
+                                  eventTieAlerts[event.name],
+                                )}
+                              >
+                                {formatTieSummary(eventTieAlerts[event.name])}
+                              </span>
+                            )}
                             <div className="flex flex-wrap gap-1">
                               {event.group.map((group, idx) => (
                                 <span

--- a/app/judge/group/leaderboard/page.js
+++ b/app/judge/group/leaderboard/page.js
@@ -5,6 +5,10 @@ import { useEffect, useState } from 'react';
 import secureLocalStorage from 'react-secure-storage';
 import { getJudgeEventData } from '@/app/_util/data';
 import { auth } from '@/app/_util/initApp';
+import {
+  calculateGroupTopCutoffTie,
+  formatTieSummary,
+} from '@/app/_util/tieDetection';
 
 export default function GroupEventLeaderboardPage() {
   const router = useRouter();
@@ -13,6 +17,7 @@ export default function GroupEventLeaderboardPage() {
   const [eventName, setEventName] = useState(null);
   const [eventMetadata, setEventMetadata] = useState(null);
   const [groups, setGroups] = useState(null);
+  const [topCutoffTie, setTopCutoffTie] = useState(null);
 
   useEffect(() => {
     if (!secureLocalStorage.getItem('user')) {
@@ -94,12 +99,12 @@ export default function GroupEventLeaderboardPage() {
               group.comment = {};
             }
 
-            if (!group.comment[eventName]) {
-              group.comment[eventName] = {};
+            if (!group.comment[_eventName]) {
+              group.comment[_eventName] = {};
             }
 
-            if (!group.comment[eventName][judgeId]) {
-              group.comment[eventName][judgeId] = '-';
+            if (!group.comment[_eventName][judgeId]) {
+              group.comment[_eventName][judgeId] = '-';
             }
           });
         });
@@ -107,6 +112,7 @@ export default function GroupEventLeaderboardPage() {
         // Sort groups by overallTotal
         groups.sort((a, b) => b.overallTotal - a.overallTotal);
 
+        setTopCutoffTie(calculateGroupTopCutoffTie(groups, _data[1]));
         setEventMetadata(_data[1]);
         setGroups(groups);
       });
@@ -196,6 +202,24 @@ export default function GroupEventLeaderboardPage() {
           </div>
         </div>
 
+        {topCutoffTie && (
+          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 justify-between">
+              <div>
+                <h3 className="text-sm font-bold text-amber-900">
+                  Top 5 tie needs review
+                </h3>
+                <p className="text-sm text-amber-800">
+                  {formatTieSummary(topCutoffTie)}.
+                </p>
+              </div>
+              <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-900 border border-amber-200">
+                Tie alert
+              </span>
+            </div>
+          </div>
+        )}
+
         <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
           <div className="p-6 border-b border-gray-100">
             <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
@@ -226,195 +250,217 @@ export default function GroupEventLeaderboardPage() {
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
-                {groups.map((group, index) => (
-                  <tr
-                    key={index}
-                    className="hover:bg-gray-50 transition-colors"
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className="text-sm font-bold text-gray-900">
-                        #{index + 1}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-bold text-gray-900">
-                        Group {index + 1}
-                      </div>
-                      <div className="text-xs text-gray-500">
-                        {group.members.length} members
-                      </div>
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="flex flex-col gap-2">
-                        {group.members.map((member, i) => (
-                          <div
-                            key={i}
-                            className="flex flex-col sm:flex-row sm:items-center gap-2"
-                          >
-                            <div className="flex items-center gap-1">
-                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
-                                {member.id}
-                              </span>
-                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-gray-50 text-gray-700 border border-gray-100">
-                                {member.gender}
-                              </span>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 text-center">
-                      <div className="flex flex-col gap-1">
-                        {Object.values(group.judgeWiseTotal).map(
-                          (total, idx) => (
-                            <span
-                              key={idx}
-                              className="text-xs font-bold text-gray-900 tabular-nums"
-                            >
-                              {parseFloat(total).toFixed(2)}
+                {groups.map((group, index) => {
+                  const isTopCutoffTie = topCutoffTie?.ids.has(
+                    group.district || 'Unknown',
+                  );
+                  return (
+                    <tr
+                      key={index}
+                      className={`hover:bg-gray-50 transition-colors ${isTopCutoffTie ? 'bg-amber-50/80' : ''}`}
+                    >
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex flex-col gap-1">
+                          <span className="text-sm font-bold text-gray-900">
+                            #{index + 1}
+                          </span>
+                          {isTopCutoffTie && (
+                            <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-900 border border-amber-200">
+                              TOP 5 TIE
                             </span>
-                          ),
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 text-center whitespace-nowrap">
-                      <span className="text-sm font-black text-blue-600 tabular-nums">
-                        {parseFloat(group.overallTotal).toFixed(2)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="flex flex-col gap-2 max-w-xs">
-                        {eventMetadata.judgeIdList.map((judgeId, i) => {
-                          const comment = group.comment[eventName][judgeId];
-                          if (!comment || comment === '-') return null;
-                          return (
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="text-sm font-bold text-gray-900">
+                          Group {index + 1}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {group.members.length} members
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col gap-2">
+                          {group.members.map((member, i) => (
                             <div
                               key={i}
-                              className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                              className="flex flex-col sm:flex-row sm:items-center gap-2"
                             >
-                              <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
-                                Judge {i + 1}
-                              </p>
-                              <p className="text-xs text-gray-700 leading-relaxed">
-                                {comment}
-                              </p>
+                              <div className="flex items-center gap-1">
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-blue-50 text-blue-700 border border-blue-100">
+                                  {member.id}
+                                </span>
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-gray-50 text-gray-700 border border-gray-100">
+                                  {member.gender}
+                                </span>
+                              </div>
                             </div>
-                          );
-                        })}
-                        {!eventMetadata.judgeIdList.some(
-                          (jid) =>
-                            group.comment[eventName][jid] &&
-                            group.comment[eventName][jid] !== '-',
-                        ) && (
-                          <span className="text-gray-400 italic text-xs">
-                            No comments
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
+                          ))}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-center">
+                        <div className="flex flex-col gap-1">
+                          {Object.values(group.judgeWiseTotal).map(
+                            (total, idx) => (
+                              <span
+                                key={idx}
+                                className="text-xs font-bold text-gray-900 tabular-nums"
+                              >
+                                {parseFloat(total).toFixed(2)}
+                              </span>
+                            ),
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-center whitespace-nowrap">
+                        <span className="text-sm font-black text-blue-600 tabular-nums">
+                          {parseFloat(group.overallTotal).toFixed(2)}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col gap-2 max-w-xs">
+                          {eventMetadata.judgeIdList.map((judgeId, i) => {
+                            const comment = group.comment[eventName][judgeId];
+                            if (!comment || comment === '-') return null;
+                            return (
+                              <div
+                                key={i}
+                                className="bg-gray-50 p-2 rounded-lg border border-gray-100"
+                              >
+                                <p className="text-[10px] uppercase font-bold text-gray-400 mb-1">
+                                  Judge {i + 1}
+                                </p>
+                                <p className="text-xs text-gray-700 leading-relaxed">
+                                  {comment}
+                                </p>
+                              </div>
+                            );
+                          })}
+                          {!eventMetadata.judgeIdList.some(
+                            (jid) =>
+                              group.comment[eventName][jid] &&
+                              group.comment[eventName][jid] !== '-',
+                          ) && (
+                            <span className="text-gray-400 italic text-xs">
+                              No comments
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
 
           {/* Mobile Card View */}
           <div className="md:hidden flex flex-col gap-4 p-4 bg-gray-50">
-            {groups.map((group, index) => (
-              <div
-                key={index}
-                className="bg-white rounded-xl p-4 shadow-sm border border-gray-200"
-              >
-                <div className="flex justify-between items-start mb-3">
-                  <div className="flex items-center gap-2">
-                    <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
-                      #{index + 1}
+            {groups.map((group, index) => {
+              const isTopCutoffTie = topCutoffTie?.ids.has(
+                group.district || 'Unknown',
+              );
+              return (
+                <div
+                  key={index}
+                  className={`bg-white rounded-xl p-4 shadow-sm border ${isTopCutoffTie ? 'border-amber-200 bg-amber-50/80' : 'border-gray-200'}`}
+                >
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
+                        #{index + 1}
+                      </span>
+                      {isTopCutoffTie && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-900 border border-amber-200">
+                          TOP 5 TIE
+                        </span>
+                      )}
+                      <div>
+                        <h3 className="text-sm font-bold text-gray-900">
+                          Group {index + 1}
+                        </h3>
+                        <p className="text-xs text-gray-500">
+                          {group.members.length} members
+                        </p>
+                      </div>
+                    </div>
+                    <span className="text-lg font-black text-blue-600">
+                      {parseFloat(group.overallTotal).toFixed(2)}
                     </span>
-                    <div>
-                      <h3 className="text-sm font-bold text-gray-900">
-                        Group {index + 1}
-                      </h3>
-                      <p className="text-xs text-gray-500">
-                        {group.members.length} members
-                      </p>
+                  </div>
+
+                  <div className="mb-4">
+                    <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
+                      Members
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {group.members.map((member, i) => (
+                        <div
+                          key={i}
+                          className="flex flex-col bg-gray-50 rounded p-2 text-xs border border-gray-100 flex-1 min-w-[100px]"
+                        >
+                          <span className="text-gray-900 font-bold text-[10px] break-all">
+                            {member.id}
+                          </span>
+                          <span className="text-gray-500 text-[10px] text-right mt-1">
+                            {member.gender}
+                          </span>
+                        </div>
+                      ))}
                     </div>
                   </div>
-                  <span className="text-lg font-black text-blue-600">
-                    {parseFloat(group.overallTotal).toFixed(2)}
-                  </span>
-                </div>
 
-                <div className="mb-4">
-                  <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
-                    Members
-                  </p>
-                  <div className="flex flex-wrap gap-2">
-                    {group.members.map((member, i) => (
+                  <div className="bg-gray-50 rounded-lg p-3 space-y-2">
+                    <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
+                      <span>Judge Scores</span>
+                      <span>Total</span>
+                    </div>
+                    {eventMetadata.judgeIdList.map((judgeId, i) => (
                       <div
                         key={i}
-                        className="flex flex-col bg-gray-50 rounded p-2 text-xs border border-gray-100 flex-1 min-w-[100px]"
+                        className="flex justify-between items-center text-xs"
                       >
-                        <span className="text-gray-900 font-bold text-[10px] break-all">
-                          {member.id}
-                        </span>
-                        <span className="text-gray-500 text-[10px] text-right mt-1">
-                          {member.gender}
+                        <span className="text-gray-600">Judge {i + 1}</span>
+                        <span className="font-bold text-gray-900">
+                          {parseFloat(
+                            group.judgeWiseTotal[judgeId] || 0,
+                          ).toFixed(2)}
                         </span>
                       </div>
                     ))}
                   </div>
-                </div>
 
-                <div className="bg-gray-50 rounded-lg p-3 space-y-2">
-                  <div className="flex justify-between items-center text-xs font-semibold text-gray-500 uppercase">
-                    <span>Judge Scores</span>
-                    <span>Total</span>
-                  </div>
-                  {eventMetadata.judgeIdList.map((judgeId, i) => (
-                    <div
-                      key={i}
-                      className="flex justify-between items-center text-xs"
-                    >
-                      <span className="text-gray-600">Judge {i + 1}</span>
-                      <span className="font-bold text-gray-900">
-                        {parseFloat(group.judgeWiseTotal[judgeId] || 0).toFixed(
-                          2,
-                        )}
-                      </span>
+                  {eventMetadata.judgeIdList.some(
+                    (jid) =>
+                      group.comment[eventName][jid] &&
+                      group.comment[eventName][jid] !== '-',
+                  ) && (
+                    <div className="mt-3 pt-3 border-t border-gray-100">
+                      <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
+                        Comments
+                      </p>
+                      <div className="space-y-2">
+                        {eventMetadata.judgeIdList.map((judgeId, i) => {
+                          const comment = group.comment[eventName][judgeId];
+                          if (!comment || comment === '-') return null;
+                          return (
+                            <div
+                              key={i}
+                              className="text-xs text-gray-600"
+                            >
+                              <span className="font-semibold text-gray-800">
+                                J{i + 1}:{' '}
+                              </span>{' '}
+                              {comment}
+                            </div>
+                          );
+                        })}
+                      </div>
                     </div>
-                  ))}
+                  )}
                 </div>
-
-                {eventMetadata.judgeIdList.some(
-                  (jid) =>
-                    group.comment[eventName][jid] &&
-                    group.comment[eventName][jid] !== '-',
-                ) && (
-                  <div className="mt-3 pt-3 border-t border-gray-100">
-                    <p className="text-[10px] font-bold text-gray-400 uppercase mb-2">
-                      Comments
-                    </p>
-                    <div className="space-y-2">
-                      {eventMetadata.judgeIdList.map((judgeId, i) => {
-                        const comment = group.comment[eventName][judgeId];
-                        if (!comment || comment === '-') return null;
-                        return (
-                          <div
-                            key={i}
-                            className="text-xs text-gray-600"
-                          >
-                            <span className="font-semibold text-gray-800">
-                              J{i + 1}:{' '}
-                            </span>{' '}
-                            {comment}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>

--- a/app/judge/individual/leaderboard/page.js
+++ b/app/judge/individual/leaderboard/page.js
@@ -5,6 +5,10 @@ import { useEffect, useState } from 'react';
 import secureLocalStorage from 'react-secure-storage';
 import { getJudgeEventData } from '@/app/_util/data';
 import { auth } from '@/app/_util/initApp';
+import {
+  calculateIndividualTopCutoffTie,
+  formatTieSummary,
+} from '@/app/_util/tieDetection';
 
 export default function EventLeaderboardIndiPage() {
   const router = useRouter();
@@ -15,6 +19,7 @@ export default function EventLeaderboardIndiPage() {
   const [eventMetadata, setEventMetadata] = useState(null);
   const [participants, setParticipants] = useState(null);
   const [filteredParticipants, setFilteredParticipants] = useState(null);
+  const [topCutoffTie, setTopCutoffTie] = useState(null);
 
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -89,6 +94,7 @@ export default function EventLeaderboardIndiPage() {
         // Sort _data[0] based on overallTotal
         _data[0].sort((a, b) => b.overallTotal - a.overallTotal);
 
+        setTopCutoffTie(calculateIndividualTopCutoffTie(_data[0], _data[1]));
         setEventMetadata(_data[1]);
         setParticipants(_data[0]);
         setFilteredParticipants(_data[0]);
@@ -183,6 +189,24 @@ export default function EventLeaderboardIndiPage() {
           </div>
         </div>
 
+        {topCutoffTie && (
+          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 justify-between">
+              <div>
+                <h3 className="text-sm font-bold text-amber-900">
+                  Top 5 tie needs review
+                </h3>
+                <p className="text-sm text-amber-800">
+                  {formatTieSummary(topCutoffTie)}.
+                </p>
+              </div>
+              <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-900 border border-amber-200">
+                Tie alert
+              </span>
+            </div>
+          </div>
+        )}
+
         <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
           <div className="p-6 border-b border-gray-100">
             <h2 className="text-xl font-bold text-gray-900">Leaderboard</h2>
@@ -213,15 +237,29 @@ export default function EventLeaderboardIndiPage() {
                 {filteredParticipants.map((row, index) => {
                   const isSubstituted =
                     row.substitute && row.substitute[eventMetadata.name];
+                  const isTopCutoffTie = topCutoffTie?.ids.has(row.studentId);
                   return (
                     <tr
                       key={index}
-                      className={`hover:bg-gray-50 transition-colors ${isSubstituted ? 'bg-red-50/50' : ''}`}
+                      className={`hover:bg-gray-50 transition-colors ${
+                        isTopCutoffTie
+                          ? 'bg-amber-50/80'
+                          : isSubstituted
+                            ? 'bg-red-50/50'
+                            : ''
+                      }`}
                     >
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <span className="text-sm font-bold text-gray-900">
-                          #{index + 1}
-                        </span>
+                        <div className="flex flex-col gap-1">
+                          <span className="text-sm font-bold text-gray-900">
+                            #{index + 1}
+                          </span>
+                          {isTopCutoffTie && (
+                            <span className="inline-flex w-fit items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold text-amber-900 border border-amber-200">
+                              TOP 5 TIE
+                            </span>
+                          )}
+                        </div>
                       </td>
                       <td className="px-6 py-4">
                         {isSubstituted ? (
@@ -312,13 +350,16 @@ export default function EventLeaderboardIndiPage() {
             {filteredParticipants.map((row, index) => {
               const isSubstituted =
                 row.substitute && row.substitute[eventMetadata.name];
+              const isTopCutoffTie = topCutoffTie?.ids.has(row.studentId);
               return (
                 <div
                   key={index}
                   className={`bg-white rounded-xl p-4 shadow-sm border ${
-                    isSubstituted
-                      ? 'border-red-200 bg-red-50/10'
-                      : 'border-gray-200'
+                    isTopCutoffTie
+                      ? 'border-amber-200 bg-amber-50/80'
+                      : isSubstituted
+                        ? 'border-red-200 bg-red-50/10'
+                        : 'border-gray-200'
                   }`}
                 >
                   <div className="flex justify-between items-start mb-3">
@@ -326,6 +367,11 @@ export default function EventLeaderboardIndiPage() {
                       <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-700 font-bold text-sm">
                         #{index + 1}
                       </span>
+                      {isTopCutoffTie && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-900 border border-amber-200">
+                          TOP 5 TIE
+                        </span>
+                      )}
                       {isSubstituted ? (
                         <div className="flex flex-col">
                           <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold bg-red-100 text-red-800 w-fit mb-1">


### PR DESCRIPTION
## Summary
- add reusable Top 5 cutoff tie detection for individual and group events
- show tie alert badges beside affected events on /admin/event
- show warning banners and highlight tied rows/cards on individual and group leaderboards
- covers the 4,5,6,7 same-score case by expanding the tie range around the cutoff score

## Validation
- git diff --check
- /Applications/Codex.app/Contents/Resources/node --check --input-type=module < app/_util/tieDetection.js
- manual Node checks for Top 5 tie ranges, including ranks 4-7 sharing the same score

Note: I could not run the full Next build locally because this Codex shell does not have npm, pnpm, or yarn available.

/claim #71